### PR TITLE
use absolute baseurl instead of one without protocol prefix

### DIFF
--- a/deployments/reviewer/libero-reviewer--prod.yaml
+++ b/deployments/reviewer/libero-reviewer--prod.yaml
@@ -92,7 +92,7 @@ spec:
     browsertests:
       runPostRelease: false
       testFixture: Minimal
-      baseurl: "https://libero-reviewer--staging.elifesciences.org"
+      baseurl: libero-reviewer--prod-client-canary.prod
 
     newRelic:
       enabled: true

--- a/deployments/reviewer/libero-reviewer--prod.yaml
+++ b/deployments/reviewer/libero-reviewer--prod.yaml
@@ -92,7 +92,7 @@ spec:
     browsertests:
       runPostRelease: false
       testFixture: Minimal
-      baseurl: libero-reviewer--prod-client-canary.prod
+      baseurl: "https://libero-reviewer--staging.elifesciences.org"
 
     newRelic:
       enabled: true

--- a/deployments/reviewer/libero-reviewer--stg.yaml
+++ b/deployments/reviewer/libero-reviewer--stg.yaml
@@ -79,3 +79,5 @@ spec:
       testArgs: "--fixture-meta fixtureID=staging"
       orcidLoginRequired: true
       orcidSecret: "libero-reviewer--stg-orcid"
+      baseurl: "https://libero-reviewer--staging.elifesciences.org"
+


### PR DESCRIPTION
@erkannt not sure if this is the correct way to do this but currently the value `libero-reviewer--prod-client-canary.prod` is breaking the browser test run as the url redirect is not taking us back to reviewer-staging correctly. Trying this as at least a temp fix to get pipeline green.