### PR TITLE
feat(reviewer): add reporter to staging deployment

### DIFF
--- a/deployments/reviewer/libero-reviewer--stg.yaml
+++ b/deployments/reviewer/libero-reviewer--stg.yaml
@@ -80,4 +80,14 @@ spec:
       orcidLoginRequired: true
       orcidSecret: "libero-reviewer--stg-orcid"
       baseurl: "https://libero-reviewer--staging.elifesciences.org"
+      
+    reporter:
+      enabled: false
+      image:
+        repository: liberoadmin/reviewer-reporter
+        tag: master-32175e71-20210219.1626
+      fromAddress: no-reply@elifesciences.org
+      subjectline: Reviewer Status Report (staging)
+      recipient: "xpub-tech-alerts@elifesciences.org"
+      msmtprcConfSecret: "libero-reviewer--prod-reporter-msmtprc"
 


### PR DESCRIPTION
This is get other pods past the diff check so is disabled and has no schedule values set. If we ever wanted to test this in staging we could enable.