### PR TITLE
fix: increase automation interval to work around pull rate limits

### DIFF
--- a/system/flux/flux.yaml
+++ b/system/flux/flux.yaml
@@ -14,6 +14,8 @@ spec:
   values:
     git:
       url: git@github.com:elifesciences/elife-flux-cluster
+    registry:
+      automationInterval: "60m"
     syncGarbageCollection:
       enabled: true
     prometheus:


### PR DESCRIPTION
Some context, the fluxcd automation is currently failing as it is hitting dockers pull rate limit. The correct solution would be to update to flux v2 which has changed the behaviour for checking for new images, but obviously that is quite some work and not something I really want to action now.
Looking at the chart for flux 1.10.2, I can see there are some config options to increase the interval used to check for new images in the registry, as such it seems that increasing this from the default 5 minutes to 1h should hopefully bring us under the 100 image pulls in a 6 hour window and get things working again.