### PR TITLE
fix(data-hub): tweak incorrect data-hub CPU request values to allow better scheduling

### DIFF
--- a/deployments/data-hub/data-hub--stg.yaml
+++ b/deployments/data-hub/data-hub--stg.yaml
@@ -216,7 +216,7 @@ spec:
       resources:
         requests:
           memory: 1Gi
-          cpu: 250m
+          cpu: 100m
     flower:
       resources:
         requests:
@@ -231,4 +231,4 @@ spec:
       resources:
         requests:
           memory: 1Gi
-          cpu: 800m
+          cpu: 150m


### PR DESCRIPTION
The value for CPU usage for the web pod is completely incorrect and too high (probably a copy paste from another resource request). 

This change should free more scheduling resources for the rest of the deploy. Also tweak the postgres values which are default, but very high vs actual usage.