### PR TITLE
fix(data-hub): add a CPU limit to scheduler

### DIFF
--- a/deployments/data-hub/data-hub--stg.yaml
+++ b/deployments/data-hub/data-hub--stg.yaml
@@ -227,6 +227,8 @@ spec:
         requests:
           memory: 1500Mi
           cpu: 800m
+        limits:
+          cpu: 1000m
     web:
       resources:
         requests:


### PR DESCRIPTION
The Airflow scheduler seems to use a lot of CPU when idle. This sets a CPU limit to prevent resource exhaustion of other services on the node.