### PR TITLE
fix(data-hub): reconfigure airflow schedulers interval between parsing files in an attempt to reduce idle CPU usage.

### DIFF
--- a/deployments/data-hub/data-hub--stg.yaml
+++ b/deployments/data-hub/data-hub--stg.yaml
@@ -42,7 +42,7 @@ spec:
         AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__CORE__REMOTE_LOGGING: "True"
         AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__CORE__REMOTE_BASE_LOG_FOLDER: "s3://staging-elife-data-pipeline/airflow-logs"
         AIRFLOW__CELERY__FLOWER_URL_PREFIX: "/flower"
-        AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL: 60
+        AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL: "300"
       image:
         repository: elifesciences/data-hub-with-dags_unstable
         tag: f1d91c7b417ca7c338a1ef4463035d49e99b52f9

--- a/deployments/data-hub/data-hub--stg.yaml
+++ b/deployments/data-hub/data-hub--stg.yaml
@@ -42,6 +42,7 @@ spec:
         AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__CORE__REMOTE_LOGGING: "True"
         AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__CORE__REMOTE_BASE_LOG_FOLDER: "s3://staging-elife-data-pipeline/airflow-logs"
         AIRFLOW__CELERY__FLOWER_URL_PREFIX: "/flower"
+        AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL: 60
       image:
         repository: elifesciences/data-hub-with-dags_unstable
         tag: f1d91c7b417ca7c338a1ef4463035d49e99b52f9


### PR DESCRIPTION
Could be the cause of high airflow scheduler CPU as it loops continuously looking for changes to the DAG python files. 

Set to 5 mins, though @de-code suggests if it could be disabled that would be fine too

Refs elifesciences/data-hub-issues#330