### PR TITLE
fix(data-hub): increase the AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL

### DIFF
--- a/deployments/data-hub/data-hub--stg.yaml
+++ b/deployments/data-hub/data-hub--stg.yaml
@@ -42,7 +42,7 @@ spec:
         AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__CORE__REMOTE_LOGGING: "True"
         AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__CORE__REMOTE_BASE_LOG_FOLDER: "s3://staging-elife-data-pipeline/airflow-logs"
         AIRFLOW__CELERY__FLOWER_URL_PREFIX: "/flower"
-        AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL: "30"
+        AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL: "60"
       image:
         repository: elifesciences/data-hub-with-dags_unstable
         tag: f1d91c7b417ca7c338a1ef4463035d49e99b52f9


### PR DESCRIPTION
increase the AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL value again to be 60 seconds in an attempt to reduce scheduler CPU again.

It's managed to climb backup and cause CPU throttling messages again