### PR TITLE
feature(data-hub): Turn off Airflow internal authentication

### DIFF
--- a/deployments/data-hub/data-hub--stg.yaml
+++ b/deployments/data-hub/data-hub--stg.yaml
@@ -243,6 +243,21 @@ spec:
           memory: 500Mi
           cpu: 500m
     web:
+      webserverConfig:
+        stringOverride: |-
+          from airflow import configuration as conf
+          from flask_appbuilder.security.manager import AUTH_DB
+
+          # the SQLAlchemy connection string
+          SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
+
+          # use embedded DB for auth
+          AUTH_TYPE = AUTH_DB
+
+          # disable authentication on web frontend
+          # this should be handled by oauth proxy instead
+          AUTH_ROLE_PUBLIC = 'Admin'
+
       resources:
         requests:
           memory: 900Mi


### PR DESCRIPTION
Airflow has its own authentication mechanism, but we actually rely on the cluster OAuth proxy to allow elife staff to access it.

This change should instruct airflow to allow all "guest" (i.e. unauthenticated within airflow) visits to act as administrators, and disables internal authentication as a result. All visits still need to pass the OAuth proxy first, so this is OK.

notes: Lines 248-253 are from the default `webserver_config.py` as deployed by the airflow helm chart.