### PR TITLE
Remove nginx-controller image pinning

### DIFF
--- a/system/infra/ingress-nginx-controller.yaml
+++ b/system/infra/ingress-nginx-controller.yaml
@@ -13,9 +13,6 @@ spec:
 
   values:
     controller:
-      image:
-        repository: eu.gcr.io/k8s-artifacts-prod/ingress-nginx/controller
-        tag: 0.34.0
       config:
         use-forwarded-headers: "true"
         use-http2: "true"


### PR DESCRIPTION
First step towards https://github.com/elifesciences/issues/issues/7226 is to remove the nginx-controller image pinning on the prod server. 

I've checked history of [elife-flux-test](https://github.com/elifesciences/elife-flux-test) and [elife-flux-cluster](https://github.com/elifesciences/elife-flux-cluster) and there doesn't appear to be a reason for it, just that the image pinning was removed in `flux-test` just after the files were copied to `flux-prod`.

This change will get prod and test on the same version and same image, for testing purposes.