### PR TITLE
fix(prometheus): change alert rules to only fix elevated CPU above 1.8

### DIFF
--- a/system/monitoring/alertrules-misc.yaml
+++ b/system/monitoring/alertrules-misc.yaml
@@ -24,7 +24,7 @@ spec:
         severity: warning
       annotations:
         message: |
-          Load1 / CPU > 1.5 for over an hour {{ $labels.instance }}
+          Load1 / CPU > 1.8 for over an hour {{ $labels.instance }}
     - alert: NodeCPULoadHigh
       expr: avg_over_time(instance:node_load1_per_cpu:ratio[60m]) > 4
       labels:

--- a/system/monitoring/alertrules-misc.yaml
+++ b/system/monitoring/alertrules-misc.yaml
@@ -10,7 +10,7 @@ spec:
   - name: ./misc.rules
     rules:
     - alert: KubeDeploymentReplicasNotReachingReady
-      expr: > 
+      expr: >
         (kube_replicaset_spec_replicas{job="kube-state-metrics",namespace=~".*"}
         != kube_replicaset_status_ready_replicas{job="kube-state-metrics",namespace=~".*"})
         and (changes(kube_deployment_status_replicas_updated{job="kube-state-metrics",namespace=~".*"}[5m]) == 0)
@@ -19,7 +19,7 @@ spec:
           Ready replicas doesn't match replica spec
           ReplicaSet probably failed to create Deployments.
     - alert: NodeCPULoadElevated
-      expr: avg_over_time(instance:node_load1_per_cpu:ratio[60m]) > 1.5
+      expr: avg_over_time(instance:node_load1_per_cpu:ratio[60m]) > 1.8
       labels:
         severity: warning
       annotations:


### PR DESCRIPTION
Data-hub worker is expected to fairly regularly spike to use ~1.7 CPUs over an extended period of time.
Here we're moving the alert to fire above 1.8, as that would be exceptional load over an hour.