### PR TITLE
enable ftp create directory in staging

### DIFF
--- a/deployments/data-hub/data-hub-configs.yaml
+++ b/deployments/data-hub/data-hub-configs.yaml
@@ -75,7 +75,7 @@ data:
           hostname: 'test-ftpserver'
           port: 21
           username: 'elinks'
-          createDirectory: false
+          createDirectory: true
           parametersFromFile:
             - parameterName: password
               filePathEnvName: EUROPEPMC_LABSLINK_FTP_PASSWORD_FILE_PATH


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/384

We should allow creation of the FTP directory, because we are using the test FTP server in staging.