### PR TITLE
extend test ftp port range for data transfer

### DIFF
--- a/deployments/data-hub/test-ftpserver/deployment.yaml
+++ b/deployments/data-hub/test-ftpserver/deployment.yaml
@@ -20,6 +20,17 @@ spec:
         image: delfer/alpine-ftp-server
         ports:
         - containerPort: 21
+        - containerPort: 21000
+        - containerPort: 21001
+        - containerPort: 21002
+        - containerPort: 21003
+        - containerPort: 21004
+        - containerPort: 21005
+        - containerPort: 21006
+        - containerPort: 21007
+        - containerPort: 21008
+        - containerPort: 21009
+        - containerPort: 21010
         env:
           - name: USERS
             valueFrom:

--- a/deployments/data-hub/test-ftpserver/services.yaml
+++ b/deployments/data-hub/test-ftpserver/services.yaml
@@ -14,3 +14,36 @@ spec:
   - port: 21
     protocol: TCP
     targetPort: 21
+  - port: 21000
+    protocol: TCP
+    targetPort: 21000
+  - port: 21001
+    protocol: TCP
+    targetPort: 21001
+  - port: 21002
+    protocol: TCP
+    targetPort: 21002
+  - port: 21003
+    protocol: TCP
+    targetPort: 21003
+  - port: 21004
+    protocol: TCP
+    targetPort: 21004
+  - port: 21005
+    protocol: TCP
+    targetPort: 21005
+  - port: 21006
+    protocol: TCP
+    targetPort: 21006
+  - port: 21007
+    protocol: TCP
+    targetPort: 21007
+  - port: 21008
+    protocol: TCP
+    targetPort: 21008
+  - port: 21009
+    protocol: TCP
+    targetPort: 21009
+  - port: 21010
+    protocol: TCP
+    targetPort: 21010


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/384

The data transfer failed.
Extending the port range will hopefully fix that.

Port ranges as per: https://github.com/delfer/docker-alpine-ftp-server