### PR TITLE
Switch the FTP server image used for the test FTP Server

### DIFF
--- a/deployments/data-hub/test-ftpserver/deployment.yaml
+++ b/deployments/data-hub/test-ftpserver/deployment.yaml
@@ -17,25 +17,26 @@ spec:
     spec:
       containers:
       - name: test-ftpserver
-        image: delfer/alpine-ftp-server
+        image: garethflowers/ftp-server
         ports:
         - containerPort: 21
-        - containerPort: 21000
-        - containerPort: 21001
-        - containerPort: 21002
-        - containerPort: 21003
-        - containerPort: 21004
-        - containerPort: 21005
-        - containerPort: 21006
-        - containerPort: 21007
-        - containerPort: 21008
-        - containerPort: 21009
-        - containerPort: 21010
+        - containerPort: 40000
+        - containerPort: 40001
+        - containerPort: 40002
+        - containerPort: 40003
+        - containerPort: 40004
+        - containerPort: 40005
+        - containerPort: 40006
+        - containerPort: 40007
+        - containerPort: 40008
+        - containerPort: 40009
         env:
-          - name: USERS
+          - name: FTP_USER
+            value: elinks
+          - name: FTP_PASS
             valueFrom:
               secretKeyRef:
-                key: username_password
+                key: password
                 name: europepmc-labslink-ftp-credentials--stg
           - name: ADDRESS
             value: test-ftpserver

--- a/deployments/data-hub/test-ftpserver/services.yaml
+++ b/deployments/data-hub/test-ftpserver/services.yaml
@@ -16,46 +16,42 @@ spec:
     protocol: TCP
     targetPort: 21
   - name: ftp-passive-port0
-    port: 21000
+    port: 40000
     protocol: TCP
-    targetPort: 21000
+    targetPort: 40000
   - name: ftp-passive-port1
-    port: 21001
+    port: 40001
     protocol: TCP
-    targetPort: 21001
+    targetPort: 40001
   - name: ftp-passive-port2
-    port: 21002
+    port: 40002
     protocol: TCP
-    targetPort: 21002
+    targetPort: 40002
   - name: ftp-passive-port3
-    port: 21003
+    port: 40003
     protocol: TCP
-    targetPort: 21003
+    targetPort: 40003
   - name: ftp-passive-port4
-    port: 21004
+    port: 40004
     protocol: TCP
-    targetPort: 21004
+    targetPort: 40004
   - name: ftp-passive-port5
-    port: 21005
+    port: 40005
     protocol: TCP
-    targetPort: 21005
+    targetPort: 40005
   - name: ftp-passive-port6
-    port: 21006
+    port: 40006
     protocol: TCP
-    targetPort: 21006
+    targetPort: 40006
   - name: ftp-passive-port7
-    port: 21007
+    port: 40007
     protocol: TCP
-    targetPort: 21007
+    targetPort: 40007
   - name: ftp-passive-port8
-    port: 21008
+    port: 40008
     protocol: TCP
-    targetPort: 21008
+    targetPort: 40008
   - name: ftp-passive-port9
-    port: 21009
+    port: 40009
     protocol: TCP
-    targetPort: 21009
-  - name: ftp-passive-port10
-    port: 21010
-    protocol: TCP
-    targetPort: 21010
+    targetPort: 40009


### PR DESCRIPTION
The existing test FTP server is crashing with a segmentation fault:
```
Last State:     Terminated
      Reason:       Error
      Exit Code:    139
      Started:      Wed, 23 Mar 2022 15:39:55 +0000
      Finished:     Wed, 23 Mar 2022 15:44:32 +0000
```

Replace with the FTP docker image [here](https://github.com/garethflowers/docker-ftp-server/)