### PR TITLE
reduce the number of days to request in a single batch to one

### DIFF
--- a/deployments/data-hub/data-hub-configs.yaml
+++ b/deployments/data-hub/data-hub-configs.yaml
@@ -44,7 +44,7 @@ data:
           search:
             query: '(PUBLISHER:"bioRxiv" OR PUBLISHER:"medRxiv")'
             pageSize: '1000'
-          maxDays: 10  # limit the number of days to process from start date
+          maxDays: 1  # limit the number of days to process from start date
         target:
           projectName: 'elife-data-pipeline'
           datasetName: '{ENV}'


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/380

With 10 days, there still seem to be quite a few records in view and sometimes it seems to get stuck.
Reducing it to 1 day would "lock-in" the progress made more frequently.

Only downside is that from the original start date, it might have to go over a few days without any data.
(But those requests should still be relatively quick in comparison)