### PR TITLE
fix(data-hub): request more CPU space for data-hubs

### DIFF
--- a/deployments/data-hub/data-hub--prod.yaml
+++ b/deployments/data-hub/data-hub--prod.yaml
@@ -186,7 +186,7 @@ spec:
       resources:
         requests:
           memory: 5Gi
-          cpu: 800m
+          cpu: 1700m
           ephemeral-storage: 10Gi
         limits:
           memory: 6Gi

--- a/deployments/data-hub/data-hub--stg.yaml
+++ b/deployments/data-hub/data-hub--stg.yaml
@@ -188,7 +188,7 @@ spec:
       resources:
         requests:
           memory: 4.9Gi
-          cpu: 800m
+          cpu: 1700m
           ephemeral-storage: 10Gi
         limits:
           memory: 6Gi


### PR DESCRIPTION
To stop the flapping that we sometimes see depending on which node it is deployed to, give Data hub deployments most of a node in terms of CPU resources. This should stop kubernetes deploying the data-hub with other CPU intensive, or too numerous other deployments