### PR TITLE
fix semantic scholar config path

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -154,7 +154,7 @@ spec:
       - name: GMAIL_OPEN_RESEARCH_ACCOUNT_SECRET_FILE
         value: /dag_secret_files/gmail_open_research/gmail_open_research_credentials.json
       - name: SEMANTIC_SCHOLAR_CONFIG_FILE_PATH
-        value: /dag_config_files/semantic-scholar/semantic-scholar.config.yaml
+        value: /dag_config_files/semantic-scholar.config.yaml
       - name: SURVEYMONKEY_SECRET_FILE
         value: /dag_secret_files/surveymonkey/surveymonkey_credentials.json
       - name: INITIAL_S3_FILE_LAST_MODIFIED_DATE

--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -90,6 +90,8 @@ spec:
         value: /dag_config_files/ejp-xml-data-pipeline.config.yaml
       - name: EXTRACT_KEYWORDS_FILE_PATH
         value: /dag_config_files/keyword-extraction-data-pipeline.config.yaml
+      - name: SEMANTIC_SCHOLAR_CONFIG_FILE_PATH
+        value: /dag_config_files/semantic-scholar.config.yaml
       - name: SURVEYMONKEY_DATA_CONFIG_FILE_PATH
         value: /dag_config_files/surveymonkey-data-pipeline.config.yaml
       - name: CIVICRM_EMAIL_DATA_CONFIG_FILE_PATH
@@ -153,8 +155,6 @@ spec:
         value: /dag_secret_files/gmail_production/gmail_credentials.json
       - name: GMAIL_OPEN_RESEARCH_ACCOUNT_SECRET_FILE
         value: /dag_secret_files/gmail_open_research/gmail_open_research_credentials.json
-      - name: SEMANTIC_SCHOLAR_CONFIG_FILE_PATH
-        value: /dag_config_files/semantic-scholar.config.yaml
       - name: SURVEYMONKEY_SECRET_FILE
         value: /dag_secret_files/surveymonkey/surveymonkey_credentials.json
       - name: INITIAL_S3_FILE_LAST_MODIFIED_DATE

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -91,7 +91,7 @@ spec:
       - name: EXTRACT_KEYWORDS_FILE_PATH
         value: /dag_config_files/keyword-extraction-data-pipeline.config.yaml
       - name: SEMANTIC_SCHOLAR_CONFIG_FILE_PATH
-        value: /dag_config_files/semantic-scholar/semantic-scholar.config.yaml
+        value: /dag_config_files/semantic-scholar.config.yaml
       - name: SURVEYMONKEY_DATA_CONFIG_FILE_PATH
         value: /dag_config_files/surveymonkey-data-pipeline.config.yaml
       - name: CIVICRM_EMAIL_DATA_CONFIG_FILE_PATH


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-core-airflow-dags/pull/961
fix for #593 

The config path doesn't contain `semantic-scholar` as a sub directory (copy and paste error from core dags example config). 