### PR TITLE
added semantic scholar pipeline schedule interval

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -109,7 +109,7 @@ spec:
       - name: GOOGLE_SPREADSHEET_SCHEDULE_INTERVAL
         value: "@daily"
       - name: SEMANTIC_SCHOLAR_PIPELINE_SCHEDULE_INTERVAL
-        value: "0 6 * * *" # At 06:00, every day
+        value: "0 10 * * *" # At 10:00, every day
       - name: WEB_API_SCHEDULE_INTERVAL
         value: "25 2 * * *"  # At 02:25
         # At minute 25 past every hour :

--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -108,9 +108,10 @@ spec:
         value: "@daily"
       - name: GOOGLE_SPREADSHEET_SCHEDULE_INTERVAL
         value: "@daily"
-        # At 02:25 :
+      - name: SEMANTIC_SCHOLAR_PIPELINE_SCHEDULE_INTERVAL
+        value: "0 6 * * *" # At 06:00, every day
       - name: WEB_API_SCHEDULE_INTERVAL
-        value: "25 2 * * *"
+        value: "25 2 * * *"  # At 02:25
         # At minute 25 past every hour :
       - name: S3_CSV_SCHEDULE_INTERVAL
         value: "25 * * * *"

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -108,6 +108,8 @@ spec:
         value: "@daily"
       - name: GOOGLE_SPREADSHEET_SCHEDULE_INTERVAL
         value: "@daily"
+      - name: SEMANTIC_SCHOLAR_PIPELINE_SCHEDULE_INTERVAL
+        value: "0 6 * * *" # At 06:00, every day
       - name: WEB_API_SCHEDULE_INTERVAL
         value: "25 2 * * *" # At 02:25
         # At minute 25 past every hour :

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -109,7 +109,7 @@ spec:
       - name: GOOGLE_SPREADSHEET_SCHEDULE_INTERVAL
         value: "@daily"
       - name: SEMANTIC_SCHOLAR_PIPELINE_SCHEDULE_INTERVAL
-        value: "0 6 * * *" # At 06:00, every day
+        value: "0 10 * * *" # At 10:00, every day
       - name: WEB_API_SCHEDULE_INTERVAL
         value: "25 2 * * *" # At 02:25
         # At minute 25 past every hour :


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-core-airflow-dags/pull/961

Tested the pipeline manually, in both staging and prod.
This enables the schedule to run daily.