### PR TITLE
added AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_CMD

### DIFF
--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -42,6 +42,7 @@ spec:
         AIRFLOW__CORE__REMOTE_LOGGING: "True"
         AIRFLOW__CORE__REMOTE_BASE_LOG_FOLDER: "s3://staging-elife-data-pipeline/airflow-logs"
         AIRFLOW__CORE__REMOTE_LOG_CONN_ID: "aws_default"
+        AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_CMD: "bash -c 'eval \"$DATABASE_SQLALCHEMY_CMD\"'"
         AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__CORE__REMOTE_LOGGING: "True"
         AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__CORE__REMOTE_BASE_LOG_FOLDER: "s3://staging-elife-data-pipeline/airflow-logs"
         AIRFLOW__CELERY__FLOWER_URL_PREFIX: "/flower"


### PR DESCRIPTION
```log
Traceback (most recent call last):
  File "/home/airflow/.local/bin/airflow", line 5, in <module>
    from airflow.__main__ import main
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/__init__.py", line 35, in <module>
    from airflow import settings
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/settings.py", line 35, in <module>
    from airflow.configuration import AIRFLOW_HOME, WEBSERVER_CONFIG, conf  # NOQA F401
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/configuration.py", line 1345, in <module>
    conf.validate()
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/configuration.py", line 293, in validate
    self._validate_config_dependencies()
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/configuration.py", line 387, in _validate_config_dependencies
    raise AirflowConfigException(f"error: cannot use sqlite with the {self.get('core', 'executor')}")
airflow.exceptions.AirflowConfigException: error: cannot use sqlite with the CeleryExecutor
```

https://github.com/airflow-helm/charts/issues/572#issuecomment-1115001572