### PR TITLE
removed legacyCommands section

### DIFF
--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -31,8 +31,6 @@ spec:
     airflow:
       # remove multi-user settings
       usersUpdate: false
-      legacyCommands:
-        enabled: false
       config:
         AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "True"
         AIRFLOW__CORE__DAG_CONCURRENCY: "100"


### PR DESCRIPTION
```
airflow command error: argument GROUP_OR_COMMAND: `airflow checkdb` command, has been removed, please use `airflow db check`, see help above.
```

https://github.com/airflow-helm/charts/blob/main/charts/airflow/values.yaml