### PR TITLE
reduce semantic scholar batch size to 250

### DIFF
--- a/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
+++ b/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
@@ -34,4 +34,4 @@ semanticScholar:
       projectName: 'elife-data-pipeline'
       datasetName: '{ENV}'
       tableName: semantic_scholar_responses_v1
-    batchSize: 1000
+    batchSize: 250


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/432

Currently the task is being stopped after around 30 minutes (to be investigated)
The current batch size is 1000. i.e. the progress is only "saved" after that many items.
Due to the current rate limit, there is a significant gap after around 250 items.
Reducing the batch size will lock in the progress more frequently.