### PR TITLE
only retrieve biorxiv and medrxiv articles from semantic scholar

### DIFF
--- a/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
+++ b/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
@@ -9,6 +9,7 @@ semanticScholar:
               SELECT DISTINCT doi
               FROM `elife-data-pipeline.{ENV}.europepmc_preprint_servers_responses` AS response
               WHERE doi IS NOT NULL
+                  AND LOWER(bookOrReportDetails.publisher) IN ('biorxiv', 'medrxiv')
 
               UNION DISTINCT
 


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/432

The articles that we are currently mostly interested in for Sciety are from bioRxiv and medRxiv.
So adding this filter will reduce the number of articles retrieved significantly.
(In Sciety saved articles from other preprint servers, if any, would still be included)