### PR TITLE
re-enable all preprint servers for semantic scholar pipeline

### DIFF
--- a/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
+++ b/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
@@ -9,7 +9,6 @@ semanticScholar:
               SELECT DISTINCT doi
               FROM `elife-data-pipeline.{ENV}.europepmc_preprint_servers_responses` AS response
               WHERE doi IS NOT NULL
-                  AND LOWER(bookOrReportDetails.publisher) IN ('biorxiv', 'medrxiv')
 
               UNION DISTINCT
 


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/436

Now that we have the API Key configured, we should be able to retrieve more documents.