### PR TITLE
reduce Semantic Scholar 404 retry for other preprint servers

### DIFF
--- a/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
+++ b/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
@@ -26,9 +26,16 @@ semanticScholar:
                   AND (
                       provenance.http_status = 200
                       OR (
-                          -- exclude recent 404s
+                          -- exclude recent 404s for bioRxiv, medRxiv
                           provenance.http_status = 404
+                          AND STARTS_WITH(provenance.doi, '10.1101/')  -- Cold Spring Harbor Labs, including bioRxiv and medRxiv
                           AND TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), provenance.request_timestamp, HOUR) < 23
+                      )
+                      OR (
+                          -- exclude not so recent 404s other preprint servers (in particular Research Square, with larger number of missing articles)
+                          provenance.http_status = 404
+                          AND NOT STARTS_WITH(provenance.doi, '10.1101/')  -- not Cold Spring Harbor Labs
+                          AND TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), provenance.request_timestamp, DAY) < 30
                       )
                   )
     source:


### PR DESCRIPTION
There are quite a few articles receiving 404 from Semantic Scholar that are unlikely getting resolved within a day.
In particular Research Square has more than 28k such articles.
This change will retry those articles after 30 days (instead of every day).

bioRxiv and medRxiv should still be retried daily. (There are currently less than 600 articles with 404)