### PR TITLE
fix(data-hub): increase helm release timeout from 5m to 10m

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: data-hub
 spec:
   interval: 5m
+  timeout: 10m
   releaseName: data-hub--prod
   chart:
     spec:

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: data-hub
 spec:
   interval: 5m
+  timeout: 10m
   releaseName: data-hub--stg
   chart:
     spec:

--- a/deployments/data-hub/release-data-hub--test.yaml
+++ b/deployments/data-hub/release-data-hub--test.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: data-hub
 spec:
   interval: 5m
+  timeout: 10m
   releaseName: data-hub--test
   chart:
     spec:


### PR DESCRIPTION
Observed some automated releases have been failing. Plus, we're relying on the autoscaler for deployments now, and new nodes take a few minutes to be active anyway.