### PR TITLE
CrossRef Event Data via Web API

### DIFF
--- a/kustomizations/apps/data-hub-configs/crossref-event-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/crossref-event-data-pipeline.config.yaml
@@ -10,6 +10,5 @@ schemaFile:
   objectName: 'airflow-config/crossref-event/data-schema/crossref-event-schema.json'
 publisherIdPrefixes:
   - '10.7554'
-  - '10.1101'
 CrossrefEventBaseUrl: 'https://api.eventdata.crossref.org/v1/events?rows=100&mailto=h.ciplak@elifesciences.org'
 importedTimestampField: 'data_hub_imported_timestamp'

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -241,3 +241,29 @@ webApi:
       parametersFromFile:
         - parameterName: Authorization
           filePathEnvName: TWITTER_API_AUTHORIZATION_FILE_PATH
+
+  # CrossRef Event Data (Cold Spring Harbor Laboratory: mainly bioRxiv, medRxiv)
+  - dataset: '{ENV}'
+    table: crossref_event_data_web_api
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/generic-web-api/{ENV}-crossref-event-data-state-10.1101.json'
+    dataUrl:
+      urlExcludingConfigurableParameters: https://api.eventdata.crossref.org/v1/events?rows=100&mailto=h.ciplak@elifesciences.org&obj-id.prefix=10.1101&until-collected-date=2019-01-01
+      configurableParameters:
+        nextPageCursorParameterName: 'cursor'
+        defaultStartDate: '2017-01-01'
+        dateFormat: '%Y-%m-%d'
+    response:
+      nextPageCursorKeyFromResponseRoot:
+        - message
+        - next-cursor
+      itemsKeyFromResponseRoot:
+        - message
+        - events
+      totalItemsCountKeyFromResponseRoot:
+        - message
+        - total-results
+      recordTimestamp:
+        itemTimestampKeyFromItemRoot:
+          - timestamp

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -249,7 +249,7 @@ webApi:
       bucketName: '{ENV}-elife-data-pipeline'
       objectName: 'airflow-config/generic-web-api/{ENV}-crossref-event-data-state-10.1101.json'
     dataUrl:
-      urlExcludingConfigurableParameters: https://api.eventdata.crossref.org/v1/events?rows=100&mailto=h.ciplak@elifesciences.org&obj-id.prefix=10.1101&until-collected-date=2019-01-01
+      urlExcludingConfigurableParameters: https://api.eventdata.crossref.org/v1/events?rows=100&mailto=h.ciplak@elifesciences.org&obj-id.prefix=10.1101&until-collected-date=2018-01-01
       configurableParameters:
         nextPageCursorParameterName: 'cursor'
         defaultStartDate: '2017-01-01'


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/553

As I can't customise the URL for one prefix only, I added it as a separate Web API config.

I added the `until-collected-date` parameter to the URL to limit the response. The date will need to be updated later to retrieve all of the data.

I configured `crossref_event_data_web_api` as the output table in case the schema is different by using the Web API (without telling it a separate schema like we do for the CrossRef Event Data pipeline)