### PR TITLE
fixed data-hub-api gcloud secret name

### DIFF
--- a/deployments/data-hub/data-hub-api/data-hub-api--prod.yaml
+++ b/deployments/data-hub/data-hub-api/data-hub-api--prod.yaml
@@ -53,7 +53,7 @@ spec:
       volumes:
       - name: gcp-credentials-sealed-secret-volume
         secret:
-          secretName: gcp-credentials
+          secretName: gcloud
 ---
 apiVersion: v1
 kind: Service

--- a/deployments/data-hub/data-hub-api/data-hub-api--stg.yaml
+++ b/deployments/data-hub/data-hub-api/data-hub-api--stg.yaml
@@ -53,7 +53,7 @@ spec:
       volumes:
       - name: gcp-credentials-sealed-secret-volume
         secret:
-          secretName: gcp-credentials
+          secretName: gcloud
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/556

Used the wrong secret name (as I had copied it from peerscout)