### PR TITLE
deploy sciety discovery

### DIFF
--- a/deployments/data-hub/sciety-discovery/automations/sciety-discovery-stable-policy.yaml
+++ b/deployments/data-hub/sciety-discovery/automations/sciety-discovery-stable-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: sciety-discovery-stable
+  namespace: data-hub
+spec:
+  imageRepositoryRef:
+    name: sciety-discovery-stable
+    namespace: data-hub
+  policy:
+    semver:
+      range: '*'

--- a/deployments/data-hub/sciety-discovery/automations/sciety-discovery-stable-source.yaml
+++ b/deployments/data-hub/sciety-discovery/automations/sciety-discovery-stable-source.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: sciety-discovery-stable
+  namespace: data-hub
+spec:
+  interval: 5m
+  image:  ghcr.io/sciety/sciety-discovery

--- a/deployments/data-hub/sciety-discovery/automations/sciety-discovery-unstable-policy.yaml
+++ b/deployments/data-hub/sciety-discovery/automations/sciety-discovery-unstable-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: sciety-discovery-unstable
+  namespace: data-hub
+spec:
+  imageRepositoryRef:
+    name: sciety-discovery-unstable
+    namespace: data-hub
+  filterTags:
+    pattern: '^main-[a-fA-F0-9]+-(?P<ts>.*)'
+    extract: '$ts'
+  policy:
+    numerical:
+      order: asc

--- a/deployments/data-hub/sciety-discovery/automations/sciety-discovery-unstable-source.yaml
+++ b/deployments/data-hub/sciety-discovery/automations/sciety-discovery-unstable-source.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: sciety-discovery-unstable
+  namespace: data-hub
+spec:
+  interval: 5m
+  image: ghcr.io/sciety/sciety-discovery_unstable

--- a/deployments/data-hub/sciety-discovery/sciety-discovery--prod.yaml
+++ b/deployments/data-hub/sciety-discovery/sciety-discovery--prod.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sciety-discovery--prod
+  labels:
+    app: sciety-discovery--prod
+  namespace: data-hub
+spec:
+  selector:
+    matchLabels:
+      app: sciety-discovery--prod
+  template:
+    metadata:
+      labels:
+        app: sciety-discovery--prod
+    spec:
+      containers:
+      - name: sciety-discovery
+        image: ghcr.io/sciety/sciety-discovery:0.0.1 # {"$imagepolicy": "data-hub:sciety-discovery-stable"}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          timeoutSeconds: 30
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          timeoutSeconds: 30
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /root/.gcp/credentials.json
+        volumeMounts:
+        - name: gcp-credentials-sealed-secret-volume
+          mountPath: /root/.gcp
+          readOnly: true
+      volumes:
+      - name: gcp-credentials-sealed-secret-volume
+        secret:
+          secretName: gcloud
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sciety-discovery--prod
+  namespace: data-hub
+spec:
+  selector:
+    app: sciety-discovery--prod
+  ports:
+  - port: 8000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sciety-discovery--prod
+  namespace: data-hub
+  labels:
+    app: sciety-discovery--prod
+spec:
+  rules:
+    - host: sciety-discovery.elifesciences.org
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: sciety-discovery--prod
+                port:
+                  number: 8000

--- a/deployments/data-hub/sciety-discovery/sciety-discovery--stg.yaml
+++ b/deployments/data-hub/sciety-discovery/sciety-discovery--stg.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sciety-discovery--stg
+  labels:
+    app: sciety-discovery--stg
+  namespace: data-hub
+spec:
+  selector:
+    matchLabels:
+      app: sciety-discovery--stg
+  template:
+    metadata:
+      labels:
+        app: sciety-discovery--stg
+    spec:
+      containers:
+      - name: sciety-discovery
+        image: ghcr.io/sciety/sciety-discovery_unstable:latest # {"$imagepolicy": "data-hub:sciety-discovery-unstable"}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          timeoutSeconds: 30
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          timeoutSeconds: 30
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /root/.gcp/credentials.json
+        volumeMounts:
+        - name: gcp-credentials-sealed-secret-volume
+          mountPath: /root/.gcp
+          readOnly: true
+      volumes:
+      - name: gcp-credentials-sealed-secret-volume
+        secret:
+          secretName: gcloud
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sciety-discovery--stg
+  namespace: data-hub
+spec:
+  selector:
+    app: sciety-discovery--stg
+  ports:
+  - port: 8000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sciety-discovery--stg
+  namespace: data-hub
+  labels:
+    app: sciety-discovery--stg
+spec:
+  rules:
+    - host: sciety-discovery--stg.elifesciences.org
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: sciety-discovery--stg
+                port:
+                  number: 8000


### PR DESCRIPTION
Deploy sciety discovery to elife cluster for now,
Under the `data-hub` namespace to have access to the GCP credentials.

This may move to the Sciety cluster in the future.