### PR TITLE
configure CrossRef Event Data schema for Web API pipeline

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -248,6 +248,9 @@ webApi:
     stateFile:
       bucketName: '{ENV}-elife-data-pipeline'
       objectName: 'airflow-config/generic-web-api/{ENV}-crossref-event-data-state-10.1101.json'
+    schemaFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/crossref-event/data-schema/crossref-event-schema.json'
     dataUrl:
       urlExcludingConfigurableParameters: https://api.eventdata.crossref.org/v1/events?rows=100&mailto=h.ciplak@elifesciences.org&obj-id.prefix=10.1101
       configurableParameters:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/577

Configuring the schema enables the functionality that checks timestamps and sets them to None if they are not valid (according to `dateparser`)