### PR TITLE
[Data Hub config] Increase day period for bioRxiv and medRxiv apis config

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -298,7 +298,7 @@ webApi:
         defaultPageSize: 100
         dateFormat: '%Y-%m-%d'
         defaultStartDate: '2013-11-06+00:00'
-        daysDiffFromStartTillEnd: 1
+        daysDiffFromStartTillEnd: 15
     response:
       itemsKeyFromResponseRoot:
         - collection
@@ -322,7 +322,7 @@ webApi:
         defaultPageSize: 100
         dateFormat: '%Y-%m-%d'
         defaultStartDate: '2019-06-25+00:00'
-        daysDiffFromStartTillEnd: 1
+        daysDiffFromStartTillEnd: 15
     response:
       itemsKeyFromResponseRoot:
         - collection


### PR DESCRIPTION
google.api_core.exceptions.Forbidden: 403 Quota exceeded
```log
[2023-01-12, 12:42:46 UTC] {warnings.py:109} WARNING - /home/***/.local/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.biorxiv.org'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(

[2023-01-12, 12:42:49 UTC] {generate_schema.py:218} INFO - Processed 26 lines
[2023-01-12, 12:42:51 UTC] {taskinstance.py:1851} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 175, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 193, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/opt/airflow/dags/dags/web_api_data_import_pipeline.py", line 40, in web_api_data_etl
    generic_web_api_data_etl(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/generic_web_api/generic_web_api_data_etl.py", line 241, in generic_web_api_data_etl
    process_web_api_data_etl_batch(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/generic_web_api/generic_web_api_data_etl.py", line 207, in process_web_api_data_etl_batch
    load_written_data_to_bq(data_config, full_temp_file_location)
  File "/opt/airflow/git_repos/core_dag/data_pipeline/generic_web_api/generic_web_api_data_etl.py", line 272, in load_written_data_to_bq
    load_file_into_bq(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/utils/data_store/bq_data_service.py", line 76, in load_file_into_bq
    wait_for_load_job(job)
  File "/opt/airflow/git_repos/core_dag/data_pipeline/utils/data_store/bq_data_service.py", line 42, in wait_for_load_job
    job.result()
  File "/home/airflow/.local/lib/python3.8/site-packages/google/cloud/bigquery/job/base.py", line 728, in result
    return super(_AsyncJob, self).result(timeout=timeout, **kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/google/api_core/future/polling.py", line 137, in result
    raise self._exception
google.api_core.exceptions.Forbidden: 403 Quota exceeded: Your table exceeded quota for imports or query appends per table. For more information, see https://cloud.google.com/bigquery/docs/troubleshoot-quotas
[2023-01-12, 12:42:51 UTC] {taskinstance.py:1851} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 175, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 193, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/opt/airflow/dags/dags/web_api_data_import_pipeline.py", line 40, in web_api_data_etl
    generic_web_api_data_etl(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/generic_web_api/generic_web_api_data_etl.py", line 241, in generic_web_api_data_etl
    process_web_api_data_etl_batch(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/generic_web_api/generic_web_api_data_etl.py", line 207, in process_web_api_data_etl_batch
    load_written_data_to_bq(data_config, full_temp_file_location)
  File "/opt/airflow/git_repos/core_dag/data_pipeline/generic_web_api/generic_web_api_data_etl.py", line 272, in load_written_data_to_bq
    load_file_into_bq(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/utils/data_store/bq_data_service.py", line 76, in load_file_into_bq
    wait_for_load_job(job)
  File "/opt/airflow/git_repos/core_dag/data_pipeline/utils/data_store/bq_data_service.py", line 42, in wait_for_load_job
    job.result()
  File "/home/airflow/.local/lib/python3.8/site-packages/google/cloud/bigquery/job/base.py", line 728, in result
    return super(_AsyncJob, self).result(timeout=timeout, **kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/google/api_core/future/polling.py", line 137, in result
    raise self._exception
google.api_core.exceptions.Forbidden: 403 Quota exceeded: Your table exceeded quota for imports or query appends per table. For more information, see https://cloud.google.com/bigquery/docs/troubleshoot-quotas

```