### PR TITLE
Updated eJPXmlObjectKeyPattern to include XML files from new site 

### DIFF
--- a/kustomizations/apps/data-hub-configs/ejp-xml-data-pipeline--test.config.yaml
+++ b/kustomizations/apps/data-hub-configs/ejp-xml-data-pipeline--test.config.yaml
@@ -6,7 +6,7 @@ manuscriptVersionTable: 'manuscript_version_all'   #having multiple identical ma
 personTable: 'person_all'  #having multiple identical person
 personVersion2Table: 'person_v2_all'  #having multiple identical person v2
 eJPXmlBucket: 'elife-ejp-ftp-db-xml-dump--test'
-eJPXmlObjectKeyPattern: 'ejp_eLife_*'
+eJPXmlObjectKeyPattern: 'ejp_e*' # having all XML files from legacy and new side (ejp_eLife* and ejp_elife-rp*)
 eJPXmlFileNameExclusionRegexPattern: '415-0\.' #Exclude unexpeted XML filenames within the zip file
 stateFile:
   bucket: '{ENV}-elife-data-pipeline'

--- a/kustomizations/apps/data-hub-configs/ejp-xml-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/ejp-xml-data-pipeline.config.yaml
@@ -6,7 +6,7 @@ manuscriptVersionTable: 'manuscript_version_all'   #having multiple identical ma
 personTable: 'person_all'  #having multiple identical person
 personVersion2Table: 'person_v2_all'  #having multiple identical person v2
 eJPXmlBucket: 'elife-ejp-ftp-db-xml-dump'
-eJPXmlObjectKeyPattern: 'ejp_eLife_*'
+eJPXmlObjectKeyPattern: 'ejp_e*' # having all XML files from legacy and new side (ejp_eLife* and ejp_elife-rp*)
 eJPXmlFileNameExclusionRegexPattern: '415-0\.' #Exclude unexpeted XML filenames within the zip file
 stateFile:
   bucket: '{ENV}-elife-data-pipeline'


### PR DESCRIPTION
https://github.com/elifesciences/data-hub-issues/issues/491
eJPXmlObjectKeyPattern: 'ejp_e*' # having all XML files from legacy and new side (ejp_eLife* and ejp_elife-rp*)
