### PR TITLE
Data Hub, Web API: Twitter Search for bioRxiv/medRxiv and Sciety

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -258,7 +258,8 @@ webApi:
       # - 10.22541: Authorea Preprints (https://www.authorea.com)
       # - 10.2139: SSRN (https://papers.ssrn.com)
       # - 10.12688: F1000 (https://f1000research.com/, also https://wellcomeopenresearch.org)
-      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "10.22541/" OR "authorea" OR "10.2139/" OR "ssrn.com" OR "10.12688/" OR "f1000research" OR "wellcomeopenresearch" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
+      # - 10.26434: ChemRxiv (https://chemrxiv.org)
+      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "10.22541/" OR "authorea" OR "10.2139/" OR "ssrn.com" OR "10.12688/" OR "f1000research" OR "wellcomeopenresearch" OR "10.26434/" OR "chemrxiv" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
     configurableParameters:
       nextPageCursorParameterName: next_token
       fromDateParameterName: start_time

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -254,7 +254,8 @@ webApi:
       # - 10.1101: bioRxiv, medRxiv (Cold Spring Harbor Laboratory in general)
       # - 10.21203: Research Square
       # - 10.20944: Preprints.org
-      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
+      # - 10.31234: PsyArXiv
+      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
     configurableParameters:
       nextPageCursorParameterName: next_token
       fromDateParameterName: start_time

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -242,14 +242,15 @@ webApi:
         - parameterName: Authorization
           filePathEnvName: TWITTER_API_AUTHORIZATION_FILE_PATH
 
-  # Twitter API v2 Search: bioRxiv/medRxiv + Sciety
+  # Twitter API v2 Search: bioRxiv/medRxiv, ResearchSquare and Sciety
   - dataset: '{ENV}'
     table: twitter_api_v2_search_response
     stateFile:
       bucketName: '{ENV}-elife-data-pipeline'
-      objectName: airflow-config/generic-web-api/state/twitter_api_v2_search/biorxiv-medrxiv-sciety.json
+      objectName: airflow-config/generic-web-api/state/twitter_api_v2_search/biorxiv-medrxiv-rs-sciety.json
     dataUrl:
-      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
+      # We are including DOI prefix and website host for preprint servers (e.g. researchsquare links won't contain DOI in URL)
+      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
     configurableParameters:
       nextPageCursorParameterName: next_token
       fromDateParameterName: start_time

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -252,10 +252,11 @@ webApi:
       # We are including DOI prefix and website host for preprint servers (e.g. researchsquare links won't contain DOI in URL)
       # Preprint servers:
       # - 10.1101: bioRxiv, medRxiv (Cold Spring Harbor Laboratory in general)
-      # - 10.21203: Research Square
+      # - 10.21203: Research Square (https://www.researchsquare.com/)
       # - 10.20944: Preprints.org
-      # - 10.31234: PsyArXiv
-      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
+      # - 10.31234: PsyArXiv (https://psyarxiv.com/)
+      # - 10.22541: Authorea Preprints (https://www.authorea.com)
+      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "10.22541/" OR "authorea" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
     configurableParameters:
       nextPageCursorParameterName: next_token
       fromDateParameterName: start_time

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -242,15 +242,19 @@ webApi:
         - parameterName: Authorization
           filePathEnvName: TWITTER_API_AUTHORIZATION_FILE_PATH
 
-  # Twitter API v2 Search: bioRxiv/medRxiv, ResearchSquare and Sciety
+  # Twitter API v2 Search: Preprints and Sciety
   - dataset: '{ENV}'
     table: twitter_api_v2_search_response
     stateFile:
       bucketName: '{ENV}-elife-data-pipeline'
-      objectName: airflow-config/generic-web-api/state/twitter_api_v2_search/biorxiv-medrxiv-rs-sciety.json
+      objectName: airflow-config/generic-web-api/state/twitter_api_v2_search/preprints-and-sciety.json
     dataUrl:
       # We are including DOI prefix and website host for preprint servers (e.g. researchsquare links won't contain DOI in URL)
-      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
+      # Preprint servers:
+      # - 10.1101: bioRxiv, medRxiv (Cold Spring Harbor Laboratory in general)
+      # - 10.21203: Research Square
+      # - 10.20944: Preprints.org
+      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
     configurableParameters:
       nextPageCursorParameterName: next_token
       fromDateParameterName: start_time

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -257,7 +257,8 @@ webApi:
       # - 10.31234: PsyArXiv (https://psyarxiv.com/)
       # - 10.22541: Authorea Preprints (https://www.authorea.com)
       # - 10.2139: SSRN (https://papers.ssrn.com)
-      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "10.22541/" OR "authorea" OR "10.2139/" OR "ssrn.com" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
+      # - 10.12688: F1000 (https://f1000research.com/, also https://wellcomeopenresearch.org)
+      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "10.22541/" OR "authorea" OR "10.2139/" OR "ssrn.com" OR "10.12688/" OR "f1000research" OR "wellcomeopenresearch" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
     configurableParameters:
       nextPageCursorParameterName: next_token
       fromDateParameterName: start_time

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -242,6 +242,34 @@ webApi:
         - parameterName: Authorization
           filePathEnvName: TWITTER_API_AUTHORIZATION_FILE_PATH
 
+  # Twitter v2 API Search: bioRxiv/medRxiv + Sciety
+  - dataset: '{ENV}'
+    table: twitter_api_v2_search_response
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: airflow-config/generic-web-api/state/twitter_api_v2_search/biorxiv-medrxiv-sciety.json
+    dataUrl:
+      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
+    configurableParameters:
+      nextPageCursorParameterName: next_token
+      fromDateParameterName: start_time
+      toDateParameterName: end_time
+      daysDiffFromStartTillEnd: 1
+      defaultStartDate: 2023-02-04+00:00  # This can only be around 7 days in the past, otherwise it will fail
+      dateFormat: "%Y-%m-%dT%H:%M:%SZ"
+    headers:
+      parametersFromFile:
+        - parameterName: Authorization
+          filePathEnvName: TWITTER_API_AUTHORIZATION_FILE_PATH
+    response:
+      nextPageCursorKeyFromResponseRoot:
+      - meta
+      - next_token
+      recordTimestamp:
+        itemTimestampKeyFromItemRoot:
+        - data
+        - created_at
+
   # CrossRef Event Data (Cold Spring Harbor Laboratory: mainly bioRxiv, medRxiv)
   - dataset: '{ENV}'
     table: crossref_event_data_web_api

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -256,7 +256,8 @@ webApi:
       # - 10.20944: Preprints.org
       # - 10.31234: PsyArXiv (https://psyarxiv.com/)
       # - 10.22541: Authorea Preprints (https://www.authorea.com)
-      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "10.22541/" OR "authorea" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
+      # - 10.2139: SSRN (https://papers.ssrn.com)
+      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "10.22541/" OR "authorea" OR "10.2139/" OR "ssrn.com" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
     configurableParameters:
       nextPageCursorParameterName: next_token
       fromDateParameterName: start_time

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -242,7 +242,7 @@ webApi:
         - parameterName: Authorization
           filePathEnvName: TWITTER_API_AUTHORIZATION_FILE_PATH
 
-  # Twitter v2 API Search: bioRxiv/medRxiv + Sciety
+  # Twitter API v2 Search: bioRxiv/medRxiv + Sciety
   - dataset: '{ENV}'
     table: twitter_api_v2_search_response
     stateFile:

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -262,13 +262,13 @@ webApi:
       # - 10.7287: PeerJ (https://peerj.com/)
       # - 10.1590: SciELO Preprints (https://preprints.scielo.org/); DOI prefix may also contain non-preprints
       urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "10.22541/" OR "authorea" OR "10.2139/" OR "ssrn.com" OR "10.12688/" OR "f1000research" OR "wellcomeopenresearch" OR "10.26434/" OR "chemrxiv" OR "10.7287/" OR "peerj.com" OR "scielopreprints" OR "preprints.scielo.org" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
-    configurableParameters:
-      nextPageCursorParameterName: next_token
-      fromDateParameterName: start_time
-      toDateParameterName: end_time
-      daysDiffFromStartTillEnd: 1
-      defaultStartDate: 2023-02-04+00:00  # This can only be around 7 days in the past, otherwise it will fail
-      dateFormat: "%Y-%m-%dT%H:%M:%SZ"
+      configurableParameters:
+        nextPageCursorParameterName: next_token
+        fromDateParameterName: start_time
+        toDateParameterName: end_time
+        daysDiffFromStartTillEnd: 1
+        defaultStartDate: 2023-02-04+00:00  # This can only be around 7 days in the past, otherwise it will fail
+        dateFormat: "%Y-%m-%dT%H:%M:%SZ"
     headers:
       parametersFromFile:
         - parameterName: Authorization

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -259,7 +259,9 @@ webApi:
       # - 10.2139: SSRN (https://papers.ssrn.com)
       # - 10.12688: F1000 (https://f1000research.com/, also https://wellcomeopenresearch.org)
       # - 10.26434: ChemRxiv (https://chemrxiv.org)
-      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "10.22541/" OR "authorea" OR "10.2139/" OR "ssrn.com" OR "10.12688/" OR "f1000research" OR "wellcomeopenresearch" OR "10.26434/" OR "chemrxiv" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
+      # - 10.7287: PeerJ (https://peerj.com/)
+      # - 10.1590: SciELO Preprints (https://preprints.scielo.org/); DOI prefix may also contain non-preprints
+      urlExcludingConfigurableParameters: 'https://api.twitter.com/2/tweets/search/recent?query=("10.1101/" OR "biorxiv" OR "medrxiv" OR "10.21203/" OR "researchsquare.com" OR "10.20944/" OR "preprints.org" OR "10.31234/" OR "psyarxiv" OR "10.22541/" OR "authorea" OR "10.2139/" OR "ssrn.com" OR "10.12688/" OR "f1000research" OR "wellcomeopenresearch" OR "10.26434/" OR "chemrxiv" OR "10.7287/" OR "peerj.com" OR "scielopreprints" OR "preprints.scielo.org" OR "sciety.org" OR @ScietyHQ)&tweet.fields=attachments,author_id,context_annotations,conversation_id,created_at,edit_controls,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld&place.fields=contained_within,country,country_code,full_name,geo,id,name,place_type&expansions=author_id,geo.place_id&max_results=100'
     configurableParameters:
       nextPageCursorParameterName: next_token
       fromDateParameterName: start_time


### PR DESCRIPTION
This will record searches for bioRxiv/medRxiv and Sciety (might extend it to other preprint servers in the near future).

This depends on the following PR to be merged and deployed:
https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1198