### PR TITLE
Web API: Fix remove second incomplete biorxiv_medrxiv_meca_path_metadata config

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -320,8 +320,6 @@ webApi:
     table: biorxiv_medrxiv_meca_path_metadata
     dataUrl:
       urlExcludingConfigurableParameters: https://api.biorxiv.org/meca_index/elife/all
-  - dataset: '{ENV}'
-    table: biorxiv_medrxiv_meca_path_metadata
 
   # bioRxiv/medRxiv apis
   # bioRxiv api


### PR DESCRIPTION
I noticed this in the Airflow logs:

```log
AIRFLOW_CTX_DAG_RUN_ID=trig__2023-02-16T02:44:01.937240+00:00_biorxiv_medrxiv_meca_path_metadata_13
[2023-02-16, 06:29:56 UTC] {taskinstance.py:1851} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 175, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 193, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/opt/airflow/dags/dags/web_api_data_import_pipeline.py", line 39, in web_api_data_etl
    data_config = WebApiConfig.from_dict(data_config_dict, deployment_env=dep_env)
  File "/opt/airflow/git_repos/core_dag/data_pipeline/generic_web_api/generic_web_api_config.py", line 91, in from_dict
    url_excluding_configurable_parameters = api_config.get(
AttributeError: 'NoneType' object has no attribute 'get'
```

Related code:

```python
        url_excluding_configurable_parameters = api_config.get(
            "dataUrl"
        ).get("urlExcludingConfigurableParameters")
```

(Of course `dataUrl` shouldn't be "optional")

The second config doesn't seem to be needed, as `https://api.biorxiv.org/meca_index/elife/all`  also returns medrxiv content.