### PR TITLE
Increase memory requirements for Sciety Labs

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -39,10 +39,10 @@ spec:
         resources:
           limits:
             cpu: 2000m
-            memory: 512Mi
+            memory: 2048Mi
           requests:
             cpu: 100m
-            memory: 64Mi
+            memory: 1024Mi
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /root/.gcp/credentials.json

--- a/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
@@ -39,10 +39,10 @@ spec:
         resources:
           limits:
             cpu: 2000m
-            memory: 512Mi
+            memory: 2048Mi
           requests:
             cpu: 100m
-            memory: 64Mi
+            memory: 1024Mi
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /root/.gcp/credentials.json


### PR DESCRIPTION
It is now using more memory since including group lists.
(Staging is currently crash looping)