### PR TITLE
Increase the number of EPP-server instances to 3

### DIFF
--- a/deployments/epp/prod/epp-kustomization.yaml
+++ b/deployments/epp/prod/epp-kustomization.yaml
@@ -35,7 +35,7 @@ spec:
       mongodb_secret_user_key: MONGODB_DATABASE_ADMIN_USER
       mongodb_secret_pass_key: MONGODB_DATABASE_ADMIN_PASSWORD
       client_replicas: "3"
-      server_replicas: "1"
+      server_replicas: "3"
       google_tag_manager_id: "GTM-WVM8KG"
       cookie_bot_id: 0a5c50d8-fcf9-47b1-8f4f-1eaadb13941b
       s3_bucket: prod-elife-epp-data


### PR DESCRIPTION
This will increase the resilience of EPP during rollouts and cluster failures