### PR TITLE
fix(data-hub): patch the stateful set to add a liveness probe that verifies there are connections active

### DIFF
--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -373,3 +373,23 @@ spec:
       resources:
         requests:
           ephemeral-storage: "10Mi"
+  postRenderers:
+  - kustomize:
+      patchesJson6902:
+      - target:
+          apiVersion: apps/v1
+          kind: StatefulSet
+          name: data-hub--stg-worker
+        patch:
+        - op: add
+          path: /spec/template/spec/containers/0/livenessProbe
+          value:
+            initialDelaySeconds: 10
+            timeoutSeconds: 20
+            failureThreshold: 5
+            periodSeconds: 60
+            exec:
+              command: |
+                - sh
+                - -c
+                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app airflow.executors.celery_executor.app inspect ping -d celery@$(hostname)

--- a/deployments/data-hub/release-data-hub--test.yaml
+++ b/deployments/data-hub/release-data-hub--test.yaml
@@ -312,3 +312,23 @@ spec:
       resources:
         requests:
           ephemeral-storage: "10Mi"
+  postRenderers:
+  - kustomize:
+      patchesJson6902:
+      - target:
+          apiVersion: apps/v1
+          kind: StatefulSet
+          name: data-hub--test-worker
+        patch:
+        - op: add
+          path: /spec/template/spec/containers/0/livenessProbe
+          value:
+            initialDelaySeconds: 10
+            timeoutSeconds: 20
+            failureThreshold: 5
+            periodSeconds: 60
+            exec:
+              command: |
+                - sh
+                - -c
+                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app airflow.executors.celery_executor.app inspect ping -d celery@$(hostname)


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/483

Using a post-render after chart has been rendered, we can patch the statefulset to add a liveness probe checking if the connections are active. failure will restart the pod.

At time of writing, we had a hung worker in data-hub prod (as per the linked ticket). This is the result of running the script in each worker's container:

```
> kubectl exec -it -n data-hub data-hub--stg-worker-0 -- sh
Defaulted container "airflow-worker" out of: airflow-worker, log-cleanup, check-db (init), wait-for-db-migrations (init)
(airflow)CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app airflow.executors.celery_executor.app inspect ping -d celery@$(hostname)
->  celery@data-hub--stg-worker-0: OK
        pong

1 node online.

> kubectl exec -it -n data-hub data-hub--test-worker-0 -- sh
Defaulted container "airflow-worker" out of: airflow-worker, log-cleanup, check-db (init), wait-for-db-migrations (init)
(airflow)CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app airflow.executors.celery_executor.app inspect ping -d celery@$(hostname)
->  celery@data-hub--test-worker-0: OK
        pong

1 node online.

> kubectl exec -it -n data-hub data-hub--prod-worker-0 -- sh
Defaulted container "airflow-worker" out of: airflow-worker, log-cleanup, check-db (init), wait-for-db-migrations (init)
(airflow)CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app airflow.executors.celery_executor.app inspect ping -d celery@$(hostname)
Error: No nodes replied within time constraint
command terminated with exit code 69

```

Solution taken from the official (non-community) airflow helm chart: https://github.com/apache/airflow/pull/25561/files