### PR TITLE
Sciety Labs: Configure Cookiebot and GTM

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -44,6 +44,10 @@ spec:
             cpu: 100m
             memory: 1024Mi
         env:
+        - name: SCIETY_LABS_COOKIEBOT_IDENTIFIER
+          value: "56f22051-f915-4cf1-9552-7d8f64d81152"
+        - name: SCIETY_LABS_GOOGLE_TAG_MANAGER_ID
+          value: "GTM-NX7CQB4"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /root/.gcp/credentials.json
         - name: TWITTER_API_AUTHORIZATION_FILE_PATH

--- a/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
@@ -44,6 +44,10 @@ spec:
             cpu: 100m
             memory: 1024Mi
         env:
+        - name: SCIETY_LABS_COOKIEBOT_IDENTIFIER
+          value: "56f22051-f915-4cf1-9552-7d8f64d81152"
+        - name: SCIETY_LABS_GOOGLE_TAG_MANAGER_ID
+          value: "GTM-NX7CQB4"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /root/.gcp/credentials.json
         - name: TWITTER_API_AUTHORIZATION_FILE_PATH


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/644

We are using the same ids in production and staging