### PR TITLE
deploy(system/kube-system/descheduler): force registry change to overcome deprecated registry

### DIFF
--- a/system/kube-system/descheduler/release.yaml
+++ b/system/kube-system/descheduler/release.yaml
@@ -16,3 +16,6 @@ spec:
         kind: HelmRepository
         name: descheduler
       interval: 1m
+  values:
+    image:
+      repository: registry.k8s.io/descheduler/descheduler


### PR DESCRIPTION
relates to https://github.com/elifesciences/issues/issues/8216