### PR TITLE
Sciety: Exclude erased evaluations from Europe PMC Labs Link

### DIFF
--- a/kustomizations/apps/data-hub-configs/europepmc-labslink--test.config.yaml
+++ b/kustomizations/apps/data-hub-configs/europepmc-labslink--test.config.yaml
@@ -8,6 +8,7 @@ europePmcLabsLink:
         FROM `elife-data-pipeline.de_proto.v_sciety_event` AS event
         WHERE event_name = 'EvaluationRecorded'
             AND article_doi IS NOT NULL
+            AND NOT is_deleted
   xml:
     providerId: '2112'
     linkTitle: 'Read the evaluations of this preprint'

--- a/kustomizations/apps/data-hub-configs/europepmc-labslink.config.yaml
+++ b/kustomizations/apps/data-hub-configs/europepmc-labslink.config.yaml
@@ -8,6 +8,7 @@ europePmcLabsLink:
         FROM `elife-data-pipeline.de_proto.v_sciety_event` AS event
         WHERE event_name = 'EvaluationRecorded'
             AND article_doi IS NOT NULL
+            AND NOT is_deleted
   xml:
     providerId: '2112'
     linkTitle: 'Read the evaluations of this preprint'


### PR DESCRIPTION
Part of https://github.com/elifesciences/data-hub-issues/issues/689

Some evaluations were incorrectly recorded and we don't want to make them appear as evaluated in Europe PMC (or anywhere else).