### PR TITLE
Update Schedule Interval for Article XML Pipeline for initial load 

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -109,7 +109,7 @@ spec:
         value: /dag_config_files/twitter-ads-api.config.yaml
       # scheduler interval
       - name: ELIFE_ARTICLE_XML_PIPELINE_SCHEDULE_INTERVAL
-        value: "0 3 * * *" # At 03:00, every day
+        value: "*/90 * * * *" # every 90th for initial load than back to: # "0 3 * * *" # At 03:00, every day
       - name: EUROPEPMC_PIPELINE_SCHEDULE_INTERVAL
         value: "0 6 * * *" # At 06:00, every day
       - name: EUROPEPMC_LABSLNK_PIPELINE_SCHEDULE_INTERVAL


### PR DESCRIPTION
Because of Git Hub rate limit we need to import xml data partially every 90 min.