### PR TITLE
Sciety: Add support for new evaluation events

### DIFF
--- a/kustomizations/apps/data-hub-configs/europepmc-labslink--test.config.yaml
+++ b/kustomizations/apps/data-hub-configs/europepmc-labslink--test.config.yaml
@@ -5,7 +5,7 @@ europePmcLabsLink:
       projectName: 'elife-data-pipeline'
       sqlQuery: |-
         SELECT DISTINCT article_doi
-        FROM `elife-data-pipeline.de_proto.v_sciety_event` AS event
+        FROM `elife-data-pipeline.{ENV}.v_sciety_event` AS event
         WHERE event_name = 'EvaluationRecorded'
             AND article_doi IS NOT NULL
             AND NOT is_deleted

--- a/kustomizations/apps/data-hub-configs/europepmc-labslink--test.config.yaml
+++ b/kustomizations/apps/data-hub-configs/europepmc-labslink--test.config.yaml
@@ -6,7 +6,7 @@ europePmcLabsLink:
       sqlQuery: |-
         SELECT DISTINCT article_doi
         FROM `elife-data-pipeline.{ENV}.v_sciety_event` AS event
-        WHERE event_name = 'EvaluationRecorded'
+        WHERE normalized_event_name IN ('EvaluationRecorded', 'EvaluationPublicationRecorded')
             AND article_doi IS NOT NULL
             AND NOT is_deleted
   xml:

--- a/kustomizations/apps/data-hub-configs/europepmc-labslink.config.yaml
+++ b/kustomizations/apps/data-hub-configs/europepmc-labslink.config.yaml
@@ -5,7 +5,7 @@ europePmcLabsLink:
       projectName: 'elife-data-pipeline'
       sqlQuery: |-
         SELECT DISTINCT article_doi
-        FROM `elife-data-pipeline.de_proto.v_sciety_event` AS event
+        FROM `elife-data-pipeline.{ENV}.v_sciety_event` AS event
         WHERE event_name = 'EvaluationRecorded'
             AND article_doi IS NOT NULL
             AND NOT is_deleted

--- a/kustomizations/apps/data-hub-configs/europepmc-labslink.config.yaml
+++ b/kustomizations/apps/data-hub-configs/europepmc-labslink.config.yaml
@@ -6,7 +6,7 @@ europePmcLabsLink:
       sqlQuery: |-
         SELECT DISTINCT article_doi
         FROM `elife-data-pipeline.{ENV}.v_sciety_event` AS event
-        WHERE event_name = 'EvaluationRecorded'
+        WHERE normalized_event_name IN ('EvaluationRecorded', 'EvaluationPublicationRecorded')
             AND article_doi IS NOT NULL
             AND NOT is_deleted
   xml:

--- a/kustomizations/apps/data-hub-configs/semantic-scholar-recommendation.config.yaml
+++ b/kustomizations/apps/data-hub-configs/semantic-scholar-recommendation.config.yaml
@@ -30,7 +30,7 @@ semanticScholarRecommendation:
                           event.event_timestamp AS item_timestamp,
                           event.article_doi AS doi,
                           (event.event_name IN ('UserUnsavedArticle', 'ArticleRemovedFromList')) AS is_excluded,
-                      FROM `elife-data-pipeline.de_proto.v_sciety_event` AS event
+                      FROM `elife-data-pipeline.{ENV}.v_sciety_event` AS event
                       WHERE event.article_doi IS NOT NULL
                           AND event.event_name IN ('UserSavedArticle', 'UserUnsavedArticle', 'ArticleAddedToList', 'ArticleRemovedFromList')
                           -- ensure present in semantic scholar

--- a/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
+++ b/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
@@ -13,7 +13,7 @@ semanticScholar:
               UNION DISTINCT
 
               SELECT DISTINCT article_doi AS doi
-              FROM `elife-data-pipeline.de_proto.v_sciety_event`
+              FROM `elife-data-pipeline.{ENV}.v_sciety_event`
               WHERE article_doi IS NOT NULL
         exclude:
           bigQuery:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/752

Since the view is now deployed via our BigQuery Views project we can use the env related dataset (e.g. `prod`)
Then switched to `normalized_event_name` but also included `EvaluationPublicationRecorded`.
That way we can switch `normalized_event_name` to the more recent event name (`EvaluationPublicationRecorded`)