### PR TITLE
Sciety Labs: Increase readiness timeout

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -33,8 +33,8 @@ spec:
           httpGet:
             path: /
             port: http
-          initialDelaySeconds: 5
-          timeoutSeconds: 30
+          initialDelaySeconds: 10
+          timeoutSeconds: 300
           periodSeconds: 10
         resources:
           limits:

--- a/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
@@ -33,8 +33,8 @@ spec:
           httpGet:
             path: /
             port: http
-          initialDelaySeconds: 5
-          timeoutSeconds: 30
+          initialDelaySeconds: 10
+          timeoutSeconds: 300
           periodSeconds: 10
         resources:
           limits:


### PR DESCRIPTION
Currently Sciety Labs is sometimes in a restart loop because it takes too long to load the data.
This increases the timeout.

(Once we are using OpenSearch, this could reduce the data it needs to load at startup)