### PR TITLE
Sciety Labs: increase liveness timeout and period

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -26,8 +26,8 @@ spec:
           httpGet:
             path: /
             port: http
-          initialDelaySeconds: 5
-          timeoutSeconds: 30
+          initialDelaySeconds: 60
+          timeoutSeconds: 300
           periodSeconds: 30
         readinessProbe:
           httpGet:

--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -28,14 +28,14 @@ spec:
             port: http
           initialDelaySeconds: 60
           timeoutSeconds: 300
-          periodSeconds: 30
+          periodSeconds: 300
         readinessProbe:
           httpGet:
             path: /
             port: http
           initialDelaySeconds: 10
           timeoutSeconds: 300
-          periodSeconds: 10
+          periodSeconds: 300
         resources:
           limits:
             cpu: 2000m

--- a/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
@@ -26,8 +26,8 @@ spec:
           httpGet:
             path: /
             port: http
-          initialDelaySeconds: 5
-          timeoutSeconds: 30
+          initialDelaySeconds: 60
+          timeoutSeconds: 300
           periodSeconds: 30
         readinessProbe:
           httpGet:

--- a/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
@@ -27,14 +27,14 @@ spec:
             path: /
             port: http
           initialDelaySeconds: 60
-          timeoutSeconds: 300
+          timeoutSeconds: 30
           periodSeconds: 300
         readinessProbe:
           httpGet:
             path: /
             port: http
           initialDelaySeconds: 10
-          timeoutSeconds: 300
+          timeoutSeconds: 30
           periodSeconds: 300
         resources:
           limits:

--- a/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
@@ -28,14 +28,14 @@ spec:
             port: http
           initialDelaySeconds: 60
           timeoutSeconds: 300
-          periodSeconds: 30
+          periodSeconds: 300
         readinessProbe:
           httpGet:
             path: /
             port: http
           initialDelaySeconds: 10
           timeoutSeconds: 300
-          periodSeconds: 10
+          periodSeconds: 300
         resources:
           limits:
             cpu: 2000m


### PR DESCRIPTION
See #2321

Just increasing the readiness timeout didn't seem to be enough.

Getting:

```log
Warning  Unhealthy  19s (x4 over 2m19s)  kubelet            Liveness probe failed: Get "http://10.0.26.218:8000/": dial tcp 10.0.26.218:8000: connect: connection refused
  Warning  Unhealthy  9s (x11 over 2m19s)  kubelet            Readiness probe failed: Get "http://10.0.26.218:8000/": dial tcp 10.0.26.218:8000: connect: connection refused
```

Although I would have thought that liveness only starts after readiness.
Maybe I am configuring the wrong timeouts?