### PR TITLE
OpenSearch: Increased batch size to 1000

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -78,4 +78,4 @@ bigQueryToOpenSearch:
                       # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
                       ef_construction: 512
                       m: 16
-    batchSize: 100
+    batchSize: 1000


### PR DESCRIPTION
In development we reduced the batch size to 100 for quicker feedback.
But in production this is meant to be increased again (unless we are experiencing timeouts).