### PR TITLE
Sciety Labs: Increase replicas to 2 in production

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -6,6 +6,7 @@ metadata:
     app: sciety-labs--prod
   namespace: data-hub
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: sciety-labs--prod


### PR DESCRIPTION
The hope is that this will make it more likely that at least one instance is available.

Higher availability is desired as there is a dependency on the RSS feeds, a link from Sciety and Sciety might soon use the API provided by Sciety Labs.