### PR TITLE
OpenSearch: Exclude S2 papers without DOI

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -24,6 +24,7 @@ bigQueryToOpenSearch:
           FROM `elife-data-pipeline.{ENV}.v_latest_semantic_scholar_response` AS s2_response
           LEFT JOIN `elife-data-pipeline.{ENV}.v_latest_europepmc_preprint_servers_response` AS europepmc_response
               ON europepmc_response.doi = s2_response.externalIds.DOI
+          WHERE s2_response.externalIds.DOI IS NULL
     fieldNamesFor:
       id: doi
       timestamp: data_hub_imported_timestamp

--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -24,7 +24,7 @@ bigQueryToOpenSearch:
           FROM `elife-data-pipeline.{ENV}.v_latest_semantic_scholar_response` AS s2_response
           LEFT JOIN `elife-data-pipeline.{ENV}.v_latest_europepmc_preprint_servers_response` AS europepmc_response
               ON europepmc_response.doi = s2_response.externalIds.DOI
-          WHERE s2_response.externalIds.DOI IS NULL
+          WHERE s2_response.externalIds.DOI IS NOT NULL
     fieldNamesFor:
       id: doi
       timestamp: data_hub_imported_timestamp


### PR DESCRIPTION
Because the DOI is the id, it is a required field. There are currently 28 papers without a DOI.