### PR TITLE
OpenSearch: Reduce batch size to 500 due to timeout

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -79,4 +79,4 @@ bigQueryToOpenSearch:
                       # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
                       ef_construction: 512
                       m: 16
-    batchSize: 1000
+    batchSize: 500


### PR DESCRIPTION
Getting:

```text
[2023-08-23T10:08:41.468+0000] {base.py:259} WARNING - POST https://opensearch-staging:9200/_bulk [status:N/A request:10.076s]
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 466, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 461, in _make_request
    httplib_response = conn.getresponse()
  File "/usr/local/lib/python3.8/http/client.py", line 1348, in getresponse
    response.begin()
  File "/usr/local/lib/python3.8/http/client.py", line 316, in begin
    version, status, reason = self._read_status()
  File "/usr/local/lib/python3.8/http/client.py", line 277, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/local/lib/python3.8/socket.py", line 669, in readinto
    return self._sock.recv_into(b)
  File "/usr/local/lib/python3.8/ssl.py", line 1241, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/local/lib/python3.8/ssl.py", line 1099, in read
    return self._sslobj.read(len, buffer)
socket.timeout: The read operation timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/connection/http_urllib3.py", line 240, in perform_request
    response = self.pool.urlopen(
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 798, in urlopen
    retries = retries.increment(
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/util/retry.py", line 525, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/packages/six.py", line 770, in reraise
    raise value
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 714, in urlopen
    httplib_response = self._make_request(
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 468, in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 357, in _raise_timeout
    raise ReadTimeoutError(
urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='opensearch-staging', port=9200): Read timed out. (read timeout=10)
[2023-08-23T10:08:41.511+0000] {taskinstance.py:1824} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 466, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 461, in _make_request
    httplib_response = conn.getresponse()
  File "/usr/local/lib/python3.8/http/client.py", line 1348, in getresponse
    response.begin()
  File "/usr/local/lib/python3.8/http/client.py", line 316, in begin
    version, status, reason = self._read_status()
  File "/usr/local/lib/python3.8/http/client.py", line 277, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/local/lib/python3.8/socket.py", line 669, in readinto
    return self._sock.recv_into(b)
  File "/usr/local/lib/python3.8/ssl.py", line 1241, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/local/lib/python3.8/ssl.py", line 1099, in read
    return self._sslobj.read(len, buffer)
socket.timeout: The read operation timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/connection/http_urllib3.py", line 240, in perform_request
    response = self.pool.urlopen(
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 798, in urlopen
    retries = retries.increment(
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/util/retry.py", line 525, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/packages/six.py", line 770, in reraise
    raise value
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 714, in urlopen
    httplib_response = self._make_request(
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 468, in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
  File "/home/airflow/.local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 357, in _raise_timeout
    raise ReadTimeoutError(
urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='opensearch-staging', port=9200): Read timed out. (read timeout=10)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 181, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 198, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/opt/airflow/dags/dags/bigquery_to_opensearch_pipeline.py", line 40, in fetch_documents_from_bigquery_and_load_into_opensearch_task
    fetch_documents_from_bigquery_and_load_into_opensearch_from_config_list(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py", line 233, in fetch_documents_from_bigquery_and_load_into_opensearch_from_config_list
    fetch_documents_from_bigquery_and_load_into_opensearch(config)
  File "/opt/airflow/git_repos/core_dag/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py", line 223, in fetch_documents_from_bigquery_and_load_into_opensearch
    create_or_update_index_and_load_documents_into_opensearch(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py", line 198, in create_or_update_index_and_load_documents_into_opensearch
    load_documents_into_opensearch(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py", line 146, in load_documents_into_opensearch
    for _ in streaming_bulk_result_iterable:
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/helpers/actions.py", line 327, in streaming_bulk
    for data, (ok, info) in zip(
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/helpers/actions.py", line 263, in _process_bulk_chunk
    for item in gen:
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/helpers/actions.py", line 204, in _process_bulk_chunk_error
    raise error
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/helpers/actions.py", line 247, in _process_bulk_chunk
    resp = client.bulk("\n".join(bulk_actions) + "\n", *args, **kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/client/utils.py", line 179, in _wrapped
    return func(*args, params=params, headers=headers, **kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/client/__init__.py", line 411, in bulk
    return self.transport.perform_request(
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/transport.py", line 409, in perform_request
    raise e
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/transport.py", line 370, in perform_request
    status, headers_response, data = connection.perform_request(
  File "/home/airflow/.local/lib/python3.8/site-packages/opensearchpy/connection/http_urllib3.py", line 254, in perform_request
    raise ConnectionTimeout("TIMEOUT", str(e), e)
opensearchpy.exceptions.ConnectionTimeout: ConnectionTimeout caused by - ReadTimeoutError(HTTPSConnectionPool(host='opensearch-staging', port=9200): Read timed out. (read timeout=10))
[2023-08-23T10:08:41.534+0000] {taskinstance.py:1345} INFO - Marking task as FAILED. dag_id=BigQuery_To_OpenSearch_Pipeline, task_id=fetch_documents_from_bigquery_and_load_into_opensearch_task, execution_date=20230823T06545
```