### PR TITLE
OpenSearch: Reducing batch size back to 100 due to timeout

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -79,4 +79,4 @@ bigQueryToOpenSearch:
                       # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
                       ef_construction: 512
                       m: 16
-    batchSize: 500
+    batchSize: 100


### PR DESCRIPTION
Still experiencing timeouts. So reducing it back to 100.