### PR TITLE
Sciety Labs: Configure OpenSearch connection details

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
@@ -59,6 +59,14 @@ spec:
           value: /root/.secrets/twitter_api/twitter_api_authorization.txt
         - name: SEMANTIC_SCHOLAR_API_KEY_FILE_PATH
           value: /root/.secrets/semantic_scholar/semantic_scholar_api_key.txt
+        - name: OPENSEARCH_HOST
+          value: "opensearch-staging"
+        - name: OPENSEARCH_PORT
+          value: "9200"
+        - name: OPENSEARCH_USERNAME_FILE_PATH
+          value: /root/.secrets/opensearch/username
+        - name: OPENSEARCH_PASSWORD_FILE_PATH
+          value: /root/.secrets/opensearch/password
         volumeMounts:
         - name: gcp-credentials-sealed-secret-volume
           mountPath: /root/.gcp
@@ -68,6 +76,9 @@ spec:
           readOnly: true
         - name: semantic-scholar-secret-volume
           mountPath: /root/.secrets/semantic_scholar/
+          readOnly: true
+        - name: opensearch-secret-volume
+          mountPath: /root/.secrets/opensearch/
           readOnly: true
       volumes:
       - name: gcp-credentials-sealed-secret-volume
@@ -79,6 +90,9 @@ spec:
       - name: semantic-scholar-secret-volume
         secret:
           secretName: semantic-scholar
+      - name: opensearch-secret-volume
+        secret:
+          secretName: opensearch-staging-admin-password
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This is to configure OpenSearch connection details.
It will then use the newly populated index.