### PR TITLE
OpenSearch: Increased batch size and timeout

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--prod.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--prod.yaml
@@ -38,6 +38,7 @@ bigQueryToOpenSearch:
       openSearch:
         hostname: 'opensearch-prod'
         port: 9200
+        timeout: 120
         verifyCertificates: False
         secrets:
           parametersFromFile:
@@ -79,4 +80,4 @@ bigQueryToOpenSearch:
                       # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
                       ef_construction: 512
                       m: 16
-    batchSize: 100
+    batchSize: 1000

--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -38,6 +38,7 @@ bigQueryToOpenSearch:
       openSearch:
         hostname: 'opensearch-staging'
         port: 9200
+        timeout: 120
         verifyCertificates: False
         secrets:
           parametersFromFile:
@@ -79,4 +80,4 @@ bigQueryToOpenSearch:
                       # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
                       ef_construction: 512
                       m: 16
-    batchSize: 100
+    batchSize: 1000


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/763

The `timeout` is now configurable (and has a higher default value).