### PR TITLE
Sciety Labs: Use OpenSearch prod instance

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -60,9 +60,8 @@ spec:
           value: /root/.secrets/twitter_api/twitter_api_authorization.txt
         - name: SEMANTIC_SCHOLAR_API_KEY_FILE_PATH
           value: /root/.secrets/semantic_scholar/semantic_scholar_api_key.txt
-        # Note: We are using "opensearch-staging" until a production instance is available (and populated)
         - name: OPENSEARCH_HOST
-          value: "opensearch-staging"
+          value: "opensearch-prod"
         - name: OPENSEARCH_PORT
           value: "9200"
         - name: OPENSEARCH_USERNAME_FILE_PATH


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/765

This could get merged after the OpenSearch pipeline completed it's import.

The following URL should provide related articles: `https://labs.sciety.org/articles/by?article_doi=10.1101/2022.10.04.510840` at the bottom.