### PR TITLE
Web API: Retrieve evaluated article from EuropePMC

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -372,7 +372,7 @@ webApi:
           - date
   # EuropePMC: Articles that are evaluated by Sciety (via LabsLink)
   - dataset: '{ENV}'
-    table: 'europepmc_sciety_evaluated'
+    table: 'europepmc_sciety_evaluated_via_labslink'
     dataUrl:
       urlExcludingConfigurableParameters: https://www.ebi.ac.uk/europepmc/webservices/rest/search?resultType=lite&format=json&pageSize=1000&query=(SRC:PPR)%20(LABS_PUBS:%222112%22)
       configurableParameters:

--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -370,3 +370,19 @@ webApi:
       recordTimestamp:
         itemTimestampKeyFromItemRoot:
           - date
+  # EuropePMC: Articles that are evaluated by Sciety (via LabsLink)
+  - dataset: '{ENV}'
+    table: 'europepmc_sciety_evaluated'
+    dataUrl:
+      urlExcludingConfigurableParameters: https://www.ebi.ac.uk/europepmc/webservices/rest/search?resultType=lite&format=json&pageSize=1000&query=(SRC:PPR)%20(LABS_PUBS:%222112%22)
+      configurableParameters:
+        defaultPageSize: 1000
+        nextPageCursorParameterName: 'cursorMark'
+    response:
+      nextPageCursorKeyFromResponseRoot:
+        - nextCursorMark
+      itemsKeyFromResponseRoot:
+        - resultList
+        - result
+      totalItemsCountKeyFromResponseRoot:
+        - hitCount


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/771

requires https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1281

This should retrieve the all of the evaluated articles from EuropePMC.
We only need the DOI really (but the WebAPI doesn't seem to support a field selector yet).