### PR TITLE
Add replica for data-hub-api in prod

### DIFF
--- a/deployments/data-hub/data-hub-api/data-hub-api--prod.yaml
+++ b/deployments/data-hub/data-hub-api/data-hub-api--prod.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: data-hub-api--prod
     spec:
+      replicas: 2
       containers:
       - name: data-hub-api
         image: ghcr.io/elifesciences/data-hub-api:1.0.19 # {"$imagepolicy": "data-hub:data-hub-api-stable"}


### PR DESCRIPTION
Added replica to increase the availability of the DocMaps API. 