### PR TITLE
move basex-validator from helm chart to kustomization

### DIFF
--- a/deployments/basex-validator/prod/basex-validator-kustomization.yaml
+++ b/deployments/basex-validator/prod/basex-validator-kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: basex-validator--prod
+  namespace: basex-validator--prod
+spec:
+  interval: 1m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kustomizations/apps/basex-validator
+  prune: true
+  targetNamespace: basex-validator--prod
+  images:
+    - name: docker.io/elifesciences/basex-validator
+      newTag: master-ffad5973-20230922.0851 # {"$imagepolicy": "basex-validator--prod:basex-validator-stable:tag"}
+  postBuild:
+    substitute:
+      replicas: "2"
+      hostname: basex-validator--prod.elifesciences.org
+      env: prod

--- a/deployments/basex-validator/prod/namespace.yaml
+++ b/deployments/basex-validator/prod/namespace.yaml
@@ -1,0 +1,5 @@
+---
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: basex-validator--prod

--- a/deployments/basex-validator/prod/updateautomation.yaml
+++ b/deployments/basex-validator/prod/updateautomation.yaml
@@ -1,0 +1,36 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: basex-validator
+  namespace: basex-validator--prod
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  update:
+    strategy: Setters
+    path: ./deployments/basex-validator/prod
+  git:
+    commit:
+      author:
+        name: Fluxbot
+        email: flux@elifesciences.org
+      messageTemplate: |
+        release({{ .AutomationObject }}): Automatic release
+
+        Files:
+        {{ range $filename, $_ := .Updated.Files -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $_ := .Updated.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+
+        Images:
+        {{ range .Updated.Images -}}
+        - {{.}}
+        {{ end -}}

--- a/kustomizations/apps/basex-validator/automations/basex-validator-policy.yaml
+++ b/kustomizations/apps/basex-validator/automations/basex-validator-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: basex-validator-stable
+  namespace: basex-validator
+spec:
+  imageRepositoryRef:
+    name: basex-validator
+    namespace: basex-validator
+  filterTags:
+    pattern: '^master-[a-fA-F0-9]+-(?P<ts>.*)'
+    extract: '$ts'
+  policy:
+    numerical:
+      order: asc

--- a/kustomizations/apps/basex-validator/automations/basex-validator-source.yaml
+++ b/kustomizations/apps/basex-validator/automations/basex-validator-source.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: basex-validator
+  namespace: basex-validator
+spec:
+  interval: 5m
+  image: docker.io/elifesciences/basex-validator

--- a/kustomizations/apps/basex-validator/deployment.yaml
+++ b/kustomizations/apps/basex-validator/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: basex-validator
+spec:
+  replicas: ${replicas:=1}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: ${maxUnavailable:=1}
+  template:
+    spec:
+      containers:
+        - name: basex-validator
+          image: docker.io/elifesciences/basex-validator:latest
+          resources:
+            limits:
+              memory: '512Mi'
+              cpu: '1.0'
+          ports:
+            - name: http
+              containerPort: 8984
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http

--- a/kustomizations/apps/basex-validator/ingress.yaml
+++ b/kustomizations/apps/basex-validator/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: basex-validator
+spec:
+  rules:
+  - host: ${hostname}
+    http:
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: basex-validator
+              port:
+                number: 8984

--- a/kustomizations/apps/basex-validator/kustomization.yaml
+++ b/kustomizations/apps/basex-validator/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: basex-validator
+resources:
+- automations/basex-validator-policy.yaml
+- automations/basex-validator-source.yaml
+- service.yaml
+- deployment.yaml
+- ingress.yaml
+
+commonLabels:
+  app.kubernetes.io/component: basex-validator
+  app.kubernetes.io/instance: basex-validator--${env}
+  app.kubernetes.io/name: basex-validator

--- a/kustomizations/apps/basex-validator/service.yaml
+++ b/kustomizations/apps/basex-validator/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: basex-validator
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8984
+      targetPort: http
+      protocol: TCP
+      name: http


### PR DESCRIPTION
This allows us to better control the resources without having to maintain the helm chart