### PR TITLE
OpenSearch: Import more EuropePMC metadata

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -87,8 +87,59 @@ bigQueryToOpenSearch:
         sqlQuery: |-
           SELECT
               europepmc_response.doi AS doi,
+              europepmc_response.provenance.imported_timestamp AS europepmc_data_hub_imported_timestamp,
               europepmc_response.firstPublicationDate AS publication_date,
-              europepmc_response.provenance.imported_timestamp AS europepmc_data_hub_imported_timestamp
+              europepmc_response.source AS europepmc_source,
+              europepmc_response.id AS europepmc_id,
+              europepmc_response.title_with_markup AS europepmc_title_with_markup,
+              europepmc_response.abstractText AS europepmc_abstract_with_markup,
+              europepmc_response.authorString AS europepmc_author_string,
+              europepmc_response.firstIndexDate AS europepmc_first_index_date,
+              europepmc_response.dateOfRevision AS europepmc_revision_date,
+              europepmc_response.language AS europepmc_language,
+
+              ARRAY(
+                  SELECT AS STRUCT
+                      author.authorId AS author_id,
+                      author.collectiveName AS collective_name,
+                      author.firstName AS first_name,
+                      author.fullName AS full_name,
+                      author.initials,
+                      author.lastName AS last_name,
+                      ARRAY(
+                          SELECT affiliation
+                          FROM UNNEST(author.authorAffiliationDetailsList.authorAffiliation) AS affiliation
+                      ) AS affiliation_string_list
+                  FROM UNNEST(europepmc_response.authorList.author) AS author
+              ) AS europepmc_author_list,
+
+              ARRAY(
+                  SELECT AS STRUCT
+                      version.source,
+                      version.id,
+                      version.versionNumber AS version_number,
+                      version.firstPublishDate AS first_publication_date,
+                      ARRAY(
+                          SELECT publication_type
+                          FROM UNNEST(pubTypeList.pubType) AS publication_type
+                      ) AS publication_type_list
+                  FROM UNNEST(europepmc_response.versionList.version) AS version
+              ) AS europepmc_version_list,
+
+              ARRAY(
+                  SELECT AS STRUCT
+                      full_text_info.availability,
+                      full_text_info.availabilityCode AS availability_code,
+                      full_text_info.documentStyle AS documentStyle,
+                      full_text_info.site AS site,
+                      full_text_info.url,
+                  FROM UNNEST(europepmc_response.fullTextUrlList.fullTextUrl) AS full_text_info
+              ) AS europepmc_full_text_list,
+
+              ARRAY(
+                  SELECT keyword
+                  FROM UNNEST(europepmc_response.keywordList.keyword) AS keyword
+              ) AS europepmc_keyword_string_list
           FROM `elife-data-pipeline.{ENV}.v_latest_europepmc_preprint_servers_response` AS europepmc_response
           WHERE europepmc_response.doi IS NOT NULL
     fieldNamesFor:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/794

I realised I will also benefit from the title for those preprints that are not in the S2 data.
Although not yet sure how to handle it. Maybe use the EuropePMC title more.

Then also added other metadata.

It seems the OpenSearch update is taking about the same time, independent of the number of fields.