### PR TITLE
OpenSearch: Separate S2, EuropePMC and Sciety fields in `preprints_v2` (staging)

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -1,5 +1,5 @@
 bigQueryToOpenSearch:
-  - dataPipelineId: bigquery_to_opensearch_data_pipeline_s2_1
+  - dataPipelineId: bigquery_to_opensearch_data_pipeline_s2
     source:
       bigQuery:
         projectName: 'elife-data-pipeline'
@@ -19,8 +19,11 @@ bigQueryToOpenSearch:
               s2_response.provenance.imported_timestamp AS s2_data_hub_imported_timestamp,
               s2_response.provenance.request_timestamp AS s2_data_hub_request_timestamp,
               s2_response.provenance.response_timestamp AS s2_data_hub_response_timestamp,
-              s2_response.paperId AS s2_paper_id
+              s2_response.paperId AS s2_paper_id,
+              europepmc_response.firstPublicationDate AS publication_date
           FROM `elife-data-pipeline.{ENV}.v_latest_semantic_scholar_response` AS s2_response
+          LEFT JOIN `elife-data-pipeline.{ENV}.v_latest_europepmc_preprint_servers_response` AS europepmc_response
+              ON europepmc_response.doi = s2_response.externalIds.DOI
           WHERE s2_response.externalIds.DOI IS NOT NULL
     fieldNamesFor:
       id: doi
@@ -80,96 +83,7 @@ bigQueryToOpenSearch:
                       ef_construction: 512
                       m: 16
     batchSize: 1000
-  - dataPipelineId: bigquery_to_opensearch_data_pipeline_europepmc_2
-    source:
-      bigQuery:
-        projectName: 'elife-data-pipeline'
-        sqlQuery: |-
-          SELECT
-              europepmc_response.doi AS doi,
-              europepmc_response.provenance.imported_timestamp AS europepmc_data_hub_imported_timestamp,
-              europepmc_response.firstPublicationDate AS publication_date,
-              europepmc_response.source AS europepmc_source,
-              europepmc_response.id AS europepmc_id,
-              europepmc_response.title_with_markup AS europepmc_title_with_markup,
-              europepmc_response.abstractText AS europepmc_abstract_with_markup,
-              europepmc_response.authorString AS europepmc_author_string,
-              europepmc_response.firstIndexDate AS europepmc_first_index_date,
-              europepmc_response.dateOfRevision AS europepmc_revision_date,
-              europepmc_response.language AS europepmc_language,
-
-              ARRAY(
-                  SELECT AS STRUCT
-                      author.authorId AS author_id,
-                      author.collectiveName AS collective_name,
-                      author.firstName AS first_name,
-                      author.fullName AS full_name,
-                      author.initials,
-                      author.lastName AS last_name,
-                      ARRAY(
-                          SELECT affiliation
-                          FROM UNNEST(author.authorAffiliationDetailsList.authorAffiliation) AS affiliation
-                      ) AS affiliation_string_list
-                  FROM UNNEST(europepmc_response.authorList.author) AS author
-              ) AS europepmc_author_list,
-
-              ARRAY(
-                  SELECT AS STRUCT
-                      version.source,
-                      version.id,
-                      version.versionNumber AS version_number,
-                      version.firstPublishDate AS first_publication_date,
-                      ARRAY(
-                          SELECT publication_type
-                          FROM UNNEST(pubTypeList.pubType) AS publication_type
-                      ) AS publication_type_list
-                  FROM UNNEST(europepmc_response.versionList.version) AS version
-              ) AS europepmc_version_list,
-
-              ARRAY(
-                  SELECT AS STRUCT
-                      full_text_info.availability,
-                      full_text_info.availabilityCode AS availability_code,
-                      full_text_info.documentStyle AS documentStyle,
-                      full_text_info.site AS site,
-                      full_text_info.url,
-                  FROM UNNEST(europepmc_response.fullTextUrlList.fullTextUrl) AS full_text_info
-              ) AS europepmc_full_text_list,
-
-              ARRAY(
-                  SELECT keyword
-                  FROM UNNEST(europepmc_response.keywordList.keyword) AS keyword
-              ) AS europepmc_keyword_string_list
-          FROM `elife-data-pipeline.{ENV}.v_latest_europepmc_preprint_servers_response` AS europepmc_response
-          WHERE europepmc_response.doi IS NOT NULL
-    fieldNamesFor:
-      id: doi
-      timestamp: europepmc_data_hub_imported_timestamp
-    state:
-      initialState:
-        startTimestamp: '2022-10-01+00:00'
-      stateFile:
-        bucketName: '{ENV}-elife-data-pipeline'
-        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state-europepmc.json'
-    target:
-      openSearch:
-        hostname: 'opensearch-staging'
-        port: 9200
-        timeout: 120
-        verifyCertificates: False
-        secrets:
-          parametersFromFile:
-            - parameterName: username
-              filePathEnvName: OPENSEARCH_USERNAME_FILE_PATH
-            - parameterName: password
-              filePathEnvName: OPENSEARCH_PASSWORD_FILE_PATH
-        indexName: 'preprints_v1'
-        updateIndexSettings: False
-        updateMappings: True
-        operationMode: 'update'
-        upsert: True
-    batchSize: 1000
-  - dataPipelineId: bigquery_to_opensearch_data_pipeline_sciety_event_3
+  - dataPipelineId: bigquery_to_opensearch_data_pipeline_sciety_event
     source:
       bigQuery:
         projectName: 'elife-data-pipeline'

--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -97,7 +97,7 @@ bigQueryToOpenSearch:
               event.evaluation_locator,
               NULL
             )) AS evaluation_count
-          FROM `elife-data-pipeline.prod.v_sciety_event` AS event
+          FROM `elife-data-pipeline.{ENV}.v_sciety_event` AS event
           WHERE event.evaluation_locator IS NOT NULL
           GROUP BY event.article_doi
     fieldNamesFor:

--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -1,5 +1,6 @@
 bigQueryToOpenSearch:
-  - dataPipelineId: bigquery_to_opensearch_data_pipeline_s2
+  # preprints_v1
+  - dataPipelineId: bigquery_to_opensearch_preprints_v1_s2
     source:
       bigQuery:
         projectName: 'elife-data-pipeline'
@@ -83,7 +84,7 @@ bigQueryToOpenSearch:
                       ef_construction: 512
                       m: 16
     batchSize: 1000
-  - dataPipelineId: bigquery_to_opensearch_data_pipeline_sciety_event
+  - dataPipelineId: bigquery_to_opensearch_preprints_v1_sciety_event
     source:
       bigQuery:
         projectName: 'elife-data-pipeline'
@@ -121,6 +122,244 @@ bigQueryToOpenSearch:
             - parameterName: password
               filePathEnvName: OPENSEARCH_PASSWORD_FILE_PATH
         indexName: 'preprints_v1'
+        updateIndexSettings: False
+        updateMappings: True
+        operationMode: 'update'
+        upsert: True
+    batchSize: 1000
+
+  # preprints_v2
+  - dataPipelineId: bigquery_to_opensearch_preprints_v2_s2
+    source:
+      bigQuery:
+        projectName: 'elife-data-pipeline'
+        sqlQuery: |-
+          SELECT
+              s2_response.externalIds.DOI AS doi,
+
+              STRUCT(
+                s2_response.provenance.imported_timestamp AS data_hub_imported_timestamp,
+                s2_response.paperId AS paper_id,
+                s2_response.title,
+                s2_response.abstract,
+
+                ARRAY(
+                  SELECT AS STRUCT
+                    author.name,
+                    author.authorId AS s2_author_id
+                  FROM UNNEST(s2_response.authors) AS author
+                ) AS author_list,
+
+                STRUCT(
+                  s2_response.embedding.model AS model_id,
+                  s2_response.embedding.vector AS vector
+                ) AS specter_embedding_v1,
+
+                STRUCT(
+                  s2_response.tldr.model AS model_id,
+                  s2_response.tldr.text
+                ) AS tldr
+              ) AS s2
+          FROM `elife-data-pipeline.{ENV}.v_latest_semantic_scholar_response` AS s2_response
+    fieldNamesFor:
+      id: doi
+      timestamp: s2.data_hub_imported_timestamp
+    state:
+      initialState:
+        startTimestamp: '2022-05-01+00:00'
+      stateFile:
+        bucketName: '{ENV}-elife-data-pipeline'
+        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state-preprints_v2-s2.json'
+    target:
+      openSearch:
+        hostname: 'opensearch-staging'
+        port: 9200
+        timeout: 120
+        verifyCertificates: False
+        secrets:
+          parametersFromFile:
+            - parameterName: username
+              filePathEnvName: OPENSEARCH_USERNAME_FILE_PATH
+            - parameterName: password
+              filePathEnvName: OPENSEARCH_PASSWORD_FILE_PATH
+        indexName: 'preprints_v2'
+        updateIndexSettings: False
+        updateMappings: True
+        operationMode: 'update'
+        upsert: True
+        indexSettings:
+          # Note: These settings can usually only be applied to a new index.
+          #   It is important to set for example the "knn_vector" fields ahead of time.
+          #   Otherwise it may get initialised with a different type and can't be changed without re-indexing.
+          settings:
+            index:
+              # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
+              knn: True
+              "knn.algo_param.ef_search": 512
+          mappings:
+            properties:
+                doi:
+                  type: "text"
+                s2:
+                  properties:
+                    author_list:
+                      type: "nested"
+                    specter_embedding_v1:
+                      properties:
+                        vector:
+                          type: "knn_vector"
+                          dimension: 768
+                          method:
+                            # Note: we need Lucene for filter support
+                            name: "hnsw"
+                            space_type: "l2"
+                            engine: "lucene"
+                            parameters:
+                              # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
+                              ef_construction: 512
+                              m: 16
+                europepmc:
+                  properties:
+                    author_list:
+                      type: "nested"
+                    version_list:
+                      type: "nested"
+                    full_text_list:
+                      type: "nested"
+    batchSize: 1000
+  - dataPipelineId: bigquery_to_opensearch_preprints_v2_europepmc
+    source:
+      bigQuery:
+        projectName: 'elife-data-pipeline'
+        sqlQuery: |-
+          SELECT
+              europepmc_response.doi AS doi,
+
+              STRUCT(
+                  europepmc_response.source AS source,
+                  europepmc_response.provenance.imported_timestamp AS data_hub_imported_timestamp,
+                  europepmc_response.id AS id,
+                  europepmc_response.title_with_markup AS title_with_markup,
+                  europepmc_response.abstractText AS abstract_with_markup,
+                  europepmc_response.authorString AS author_string,
+                  europepmc_response.firstIndexDate AS first_index_date,
+                  europepmc_response.firstPublicationDate AS first_publication_date,
+                  europepmc_response.dateOfRevision AS revision_date,
+                  europepmc_response.language AS language,
+
+                  ARRAY(
+                      SELECT AS STRUCT
+                          author.authorId AS author_id,
+                          author.collectiveName AS collective_name,
+                          author.firstName AS first_name,
+                          author.fullName AS full_name,
+                          author.initials,
+                          author.lastName AS last_name,
+                          ARRAY(
+                              SELECT affiliation
+                              FROM UNNEST(author.authorAffiliationDetailsList.authorAffiliation) AS affiliation
+                          ) AS affiliation_string_list
+                      FROM UNNEST(europepmc_response.authorList.author) AS author
+                  ) AS author_list,
+
+                  ARRAY(
+                      SELECT AS STRUCT
+                          version.source,
+                          version.id,
+                          version.versionNumber AS version_number,
+                          version.firstPublishDate AS first_publication_date,
+                          ARRAY(
+                              SELECT publication_type
+                              FROM UNNEST(pubTypeList.pubType) AS publication_type
+                          ) AS publication_type_string_list
+                      FROM UNNEST(europepmc_response.versionList.version) AS version
+                  ) AS version_list,
+
+                  ARRAY(
+                      SELECT AS STRUCT
+                          full_text_info.availability,
+                          full_text_info.availabilityCode AS availability_code,
+                          full_text_info.documentStyle AS documentStyle,
+                          full_text_info.site AS site,
+                          full_text_info.url,
+                      FROM UNNEST(europepmc_response.fullTextUrlList.fullTextUrl) AS full_text_info
+                  ) AS full_text_list,
+
+                  ARRAY(
+                      SELECT keyword
+                      FROM UNNEST(europepmc_response.keywordList.keyword) AS keyword
+                  ) AS keyword_string_list
+              ) AS europepmc
+
+          FROM `elife-data-pipeline.{ENV}.v_latest_europepmc_preprint_servers_response` AS europepmc_response
+    fieldNamesFor:
+      id: doi
+      timestamp: europepmc.data_hub_imported_timestamp
+    state:
+      initialState:
+        startTimestamp: '2022-05-01+00:00'
+      stateFile:
+        bucketName: '{ENV}-elife-data-pipeline'
+        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state-preprints_v2-europepmc.json'
+    target:
+      openSearch:
+        hostname: 'opensearch-staging'
+        port: 9200
+        timeout: 120
+        verifyCertificates: False
+        secrets:
+          parametersFromFile:
+            - parameterName: username
+              filePathEnvName: OPENSEARCH_USERNAME_FILE_PATH
+            - parameterName: password
+              filePathEnvName: OPENSEARCH_PASSWORD_FILE_PATH
+        indexName: 'preprints_v2'
+        updateIndexSettings: False
+        updateMappings: True
+        operationMode: 'update'
+        upsert: True
+    batchSize: 1000
+  - dataPipelineId: bigquery_to_opensearch_preprints_v2_sciety
+    source:
+      bigQuery:
+        projectName: 'elife-data-pipeline'
+        sqlQuery: |-
+          SELECT
+            event.article_doi AS doi,
+            STRUCT(
+              MAX(event_timestamp) AS last_event_timestamp,
+              COUNT(DISTINCT IF(
+                NOT event.is_deleted AND event.normalized_event_name IN ('EvaluationRecorded', 'EvaluationPublicationRecorded'),
+                event.evaluation_locator,
+                NULL
+              )) AS evaluation_count
+            ) AS sciety
+          FROM `elife-data-pipeline.{ENV}.v_sciety_event` AS event
+          WHERE event.evaluation_locator IS NOT NULL
+          GROUP BY event.article_doi
+    fieldNamesFor:
+      id: doi
+      timestamp: sciety.last_event_timestamp
+    state:
+      initialState:
+        startTimestamp: '2019-01-01+00:00'
+      stateFile:
+        bucketName: '{ENV}-elife-data-pipeline'
+        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state-preprints_v2-sciety.json'
+    target:
+      openSearch:
+        hostname: 'opensearch-staging'
+        port: 9200
+        timeout: 120
+        # disable verification of certificates in development
+        verifyCertificates: False
+        secrets:
+          parametersFromFile:
+            - parameterName: username
+              filePathEnvName: OPENSEARCH_USERNAME_FILE_PATH
+            - parameterName: password
+              filePathEnvName: OPENSEARCH_PASSWORD_FILE_PATH
+        indexName: 'preprints_v2'
         updateIndexSettings: False
         updateMappings: True
         operationMode: 'update'


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/794
depends on https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1312 (for support of key paths for timestamp)

This reverts #2427 and #2438
Instead a new index `preprints_v2` is populated with the following top-level fields:

- doi
- s2
- europepmc
- sciety