### PR TITLE
Opensearch fix preprints s2 null doi

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -293,6 +293,7 @@ bigQueryToOpenSearch:
               ) AS europepmc
 
           FROM `elife-data-pipeline.{ENV}.v_latest_europepmc_preprint_servers_response` AS europepmc_response
+          WHERE europepmc_response.doi IS NOT NULL
     fieldNamesFor:
       id: doi
       timestamp: europepmc.data_hub_imported_timestamp

--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -161,6 +161,7 @@ bigQueryToOpenSearch:
                 ) AS tldr
               ) AS s2
           FROM `elife-data-pipeline.{ENV}.v_latest_semantic_scholar_response` AS s2_response
+          WHERE s2_response.externalIds.DOI IS NOT NULL
     fieldNamesFor:
       id: doi
       timestamp: s2.data_hub_imported_timestamp


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/794
follow-up for #2443

The query didn't exclude NULL dois (mostly in S2, only one in EuropePMC)