### PR TITLE
Data Hub: Fix Airflow Logs not shown in UI, move mount to `web`

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -355,14 +355,6 @@ spec:
           memory: 500Mi
           cpu: 1200m
           ephemeral-storage: "50Mi"
-      extraVolumeMounts:
-      - name: aws-secret-volume
-        mountPath: /home/airflow/.aws
-        readOnly: true
-      extraVolumes:
-      - name: aws-secret-volume
-        secret:
-          secretName: credentials
     web:
       webserverConfig:
         stringOverride: |
@@ -387,6 +379,14 @@ spec:
         initialDelaySeconds: 60
       readinessProbe:
         initialDelaySeconds: 60
+      extraVolumeMounts:
+      - name: aws-secret-volume
+        mountPath: /home/airflow/.aws
+        readOnly: true
+      extraVolumes:
+      - name: aws-secret-volume
+        secret:
+          secretName: credentials
     triggerer:
       resources:
         requests:

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -358,14 +358,6 @@ spec:
           memory: 500Mi
           cpu: 1200m
           ephemeral-storage: "50Mi"
-      extraVolumeMounts:
-      - name: aws-secret-volume
-        mountPath: /home/airflow/.aws
-        readOnly: true
-      extraVolumes:
-      - name: aws-secret-volume
-        secret:
-          secretName: credentials
     web:
       webserverConfig:
         stringOverride: |
@@ -390,6 +382,14 @@ spec:
         initialDelaySeconds: 60
       readinessProbe:
         initialDelaySeconds: 60
+      extraVolumeMounts:
+      - name: aws-secret-volume
+        mountPath: /home/airflow/.aws
+        readOnly: true
+      extraVolumes:
+      - name: aws-secret-volume
+        secret:
+          secretName: credentials
     triggerer:
       resources:
         requests:

--- a/deployments/data-hub/release-data-hub--test.yaml
+++ b/deployments/data-hub/release-data-hub--test.yaml
@@ -282,14 +282,6 @@ spec:
           memory: 500Mi
           cpu: 1200m
           ephemeral-storage: "50Mi"
-      extraVolumeMounts:
-      - name: aws-secret-volume
-        mountPath: /home/airflow/.aws
-        readOnly: true
-      extraVolumes:
-      - name: aws-secret-volume
-        secret:
-          secretName: credentials
     web:
       # Fix for helm chart 8.6.0 not supporting airflow 2.3
       webserverConfig:
@@ -315,6 +307,14 @@ spec:
         initialDelaySeconds: 60
       readinessProbe:
         initialDelaySeconds: 60
+      extraVolumeMounts:
+      - name: aws-secret-volume
+        mountPath: /home/airflow/.aws
+        readOnly: true
+      extraVolumes:
+      - name: aws-secret-volume
+        secret:
+          secretName: credentials
     triggerer:
       resources:
         requests:


### PR DESCRIPTION
part of elifesciences/data-hub-issues#785
Follow-up on 2437

This should make the logs available in the Airflow UI, in the "traditional" view.

In #2437 the mount was incorrectly added to the `scheduler` instead of `web`
This PR fixes that by moving the mount to `web`