### PR TITLE
Sciety Labs: Configure OpenSearch preprints_v2

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -68,6 +68,12 @@ spec:
           value: /root/.secrets/opensearch/username
         - name: OPENSEARCH_PASSWORD_FILE_PATH
           value: /root/.secrets/opensearch/password
+        # new environment variables that will become active with code change
+        - name: OPENSEARCH_INDEX_V2_NAME
+          value: "preprints_v2"
+        - name: OPENSEARCH_INDEX_V2_EMBEDDING_VECTOR_MAPPING_NAME
+          value: "s2.specter_embedding_v1.vector"
+        # deprecated
         - name: OPENSEARCH_INDEX_NAME
           value: "preprints_v1"
         - name: OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME

--- a/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
@@ -67,6 +67,12 @@ spec:
           value: /root/.secrets/opensearch/username
         - name: OPENSEARCH_PASSWORD_FILE_PATH
           value: /root/.secrets/opensearch/password
+        # new environment variables that will become active with code change
+        - name: OPENSEARCH_INDEX_V2_NAME
+          value: "preprints_v2"
+        - name: OPENSEARCH_INDEX_V2_EMBEDDING_VECTOR_MAPPING_NAME
+          value: "s2.specter_embedding_v1.vector"
+        # deprecated
         - name: OPENSEARCH_INDEX_NAME
           value: "preprints_v1"
         - name: OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/794
for https://github.com/sciety/sciety-labs/pull/239

The deprecated environment variables can be removed after the code change is deployed.