### PR TITLE
Web API: S2 Embeddings, fixed include query

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -419,6 +419,7 @@ webApi:
               AND europepmc_response.doi NOT IN (
                 SELECT s2_response.externalIds.DOI
                 FROM `elife-data-pipeline.{ENV}.v_latest_semantic_scholar_response` AS s2_response
+                WHERE s2_response.externalIds.DOI IS NOT NULL
               )
             ORDER BY europepmc_response.doi
       exclude:


### PR DESCRIPTION
part of elifesciences/data-hub-issues#798
Follow-up fix for #2472

The query did not return any results because the sub query contained NULL DOIs.