### PR TITLE
Data Hub: Mount config to scheduler (staging)

### DIFF
--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -358,6 +358,14 @@ spec:
           memory: 500Mi
           cpu: 1000m
           ephemeral-storage: "50Mi"
+      extraVolumeMounts:
+      - name: data-hub-config-volume
+        mountPath: /dag_config_files/
+        readOnly: true
+      extraVolumes:
+      - name: data-hub-config-volume
+        configMap:
+          name: data-hub-configs
     web:
       webserverConfig:
         stringOverride: |


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/810

After the following change:
https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1338

We are seeing:

```text
Broken DAG: [/opt/airflow/dags/dags/web_api_data_import_pipeline.py] Traceback (most recent call last):
  File "/opt/airflow/git_repos/core_dag/data_pipeline/utils/pipeline_config.py", line 269, in get_pipeline_config_for_env_name_and_config_parser
    get_yaml_file_as_dict(conf_file_path),
  File "/opt/airflow/git_repos/core_dag/data_pipeline/utils/pipeline_file_io.py", line 45, in get_yaml_file_as_dict
    with open(file_location, 'r', encoding='UTF-8') as yaml_file:
FileNotFoundError: [Errno 2] No such file or directory: '/dag_config_files/web-api-data-pipeline.config.yaml'
```

In development, we now mount it to both scheduler and web. It is not clear whether we need it on both when deployed. Therefore starting with the scheduler.