### PR TITLE
Data Hub: Mount config to scheduler (prod and test)

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -355,6 +355,14 @@ spec:
           memory: 500Mi
           cpu: 1200m
           ephemeral-storage: "50Mi"
+      extraVolumeMounts:
+      - name: data-hub-config-volume
+        mountPath: /dag_config_files/
+        readOnly: true
+      extraVolumes:
+      - name: data-hub-config-volume
+        configMap:
+          name: data-hub-configs
     web:
       webserverConfig:
         stringOverride: |

--- a/deployments/data-hub/release-data-hub--test.yaml
+++ b/deployments/data-hub/release-data-hub--test.yaml
@@ -282,6 +282,14 @@ spec:
           memory: 500Mi
           cpu: 1000m
           ephemeral-storage: "50Mi"
+      extraVolumeMounts:
+      - name: data-hub-config-volume
+        mountPath: /dag_config_files/
+        readOnly: true
+      extraVolumes:
+      - name: data-hub-config-volume
+        configMap:
+          name: data-hub-configs
     web:
       # Fix for helm chart 8.6.0 not supporting airflow 2.3
       webserverConfig:


### PR DESCRIPTION
part of elifesciences/data-hub-issues#810

After the following change:
elifesciences/data-hub-core-airflow-dags#1338

Same as #2487 but applying to prod and test