### PR TITLE
S2 pipelines: added missing keyFieldNameFromInclude

### DIFF
--- a/kustomizations/apps/data-hub-configs/semantic-scholar-recommendation.config.yaml
+++ b/kustomizations/apps/data-hub-configs/semantic-scholar-recommendation.config.yaml
@@ -78,6 +78,7 @@ semanticScholarRecommendation:
               SELECT response.provenance.list_key
               FROM `elife-data-pipeline.{ENV}.semantic_scholar_recommendation_response_v1` AS response
               WHERE response.provenance.http_status = 200
+          keyFieldNameFromInclude: 'list_key'
     source:
       apiUrl: 'https://api.semanticscholar.org/recommendations/v1/papers'
       params:

--- a/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
+++ b/kustomizations/apps/data-hub-configs/semantic-scholar.config.yaml
@@ -38,6 +38,7 @@ semanticScholar:
                           AND TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), provenance.request_timestamp, DAY) < 30
                       )
                   )
+          keyFieldNameFromInclude: 'doi'
     source:
       apiUrl: 'https://api.semanticscholar.org/graph/v1/paper/{doi}'
       params:


### PR DESCRIPTION
The new field `keyFieldNameFromInclude` was introduced (and made required) as part of https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1338

That should hopefully fix the current failure of the two S2 pipelines.