### PR TITLE
Sciety Labs: Increased replicas to match number of OpenSearch nodes

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -6,7 +6,7 @@ metadata:
     app: sciety-labs--prod
   namespace: data-hub
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: sciety-labs--prod


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/818

This may make it slightly more likely that all three OpenSearch nodes are being utilised. (Although now guarantee)