### PR TITLE
Sciety Labs: Redirect to preferred host

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -49,6 +49,8 @@ spec:
             cpu: 250m
             memory: 1024Mi
         env:
+        - name: SCIETY_LABS_PREFERRED_HOST
+          value: "labs.sciety.org"
         - name: SCIETY_LABS_COOKIEBOT_IDENTIFIER
           value: "56f22051-f915-4cf1-9552-7d8f64d81152"
         - name: SCIETY_LABS_GOOGLE_TAG_MANAGER_ID


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/835

This is redirecting to `labs.sciety.org`

depends on https://github.com/sciety/sciety-labs/pull/306 to be effective