### PR TITLE
Sciety Labs: Redirect to preferred host (via nginx)

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -122,6 +122,11 @@ metadata:
   namespace: data-hub
   labels:
     app: sciety-labs--prod
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host != 'labs.sciety.org' ) {
+        rewrite ^ https://labs.sciety.org$request_uri permanent;
+      }
 spec:
   rules:
     - host: sciety-labs.elifesciences.org


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/835
See https://github.com/elifesciences/elife-flux-cluster/pull/2561#issuecomment-1888650712

This is redirecting to `labs.sciety.org`