### PR TITLE
Attempt a redirect to Preferred Host using `X-Forwarded-For` header

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--stg.yaml
@@ -121,6 +121,11 @@ metadata:
   namespace: data-hub
   labels:
     app: sciety-labs--stg
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($http_x_original_forwarded_for != 'labs.sciety.org') {
+        rewrite ^ https://labs.sciety.org$request_uri permanent;
+      }
 spec:
   rules:
     - host: sciety-labs--stg.elifesciences.org


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/835
See https://github.com/elifesciences/elife-flux-cluster/pull/2561#issuecomment-1888650712
Follow on from failed attempt https://github.com/elifesciences/elife-flux-cluster/pull/2563