### PR TITLE
Sciety Labs: Fixed duplicated query parameters when redirecting to preferred host

### DIFF
--- a/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
+++ b/deployments/data-hub/sciety-labs/sciety-labs--prod.yaml
@@ -125,7 +125,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($http_x_forwarded_host != 'labs.sciety.org') {
-        rewrite ^ https://labs.sciety.org$request_uri permanent;
+        rewrite ^ https://labs.sciety.org$request_uri? permanent;
       }
 spec:
   rules:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/835 See https://github.com/elifesciences/data-hub-issues/issues/835#issuecomment-1894222481

Example:
https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#taxing-rewrites

Which mentions we could maybe also use `return`.

And a similar issue:
https://stackoverflow.com/questions/28081159/nginx-request-uri-has-duplicated-query-parameter

Which quotes the [documentation](http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite):

> If a replacement string includes the new request arguments, the previous request arguments are appended after them. If this is undesired, putting a question mark at the end of a replacement string avoids having them appended, for example:
>
>  rewrite ^/users/(.*)$ /show?user=$1? last;