### PR TITLE
[Data Hub Staging]: Update Google Spreadsheet Data Pipeline Scheduler Period

### DIFF
--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -129,13 +129,14 @@ spec:
         value: "0 6 * * *" # At 06:00, every day
       - name: EUROPEPMC_LABSLNK_PIPELINE_SCHEDULE_INTERVAL
         value: "0 10 * * *" # At 10:00, every day
-        # At 07:00 on every day-of-week from Monday through Friday :
+        # At 07:00 on every day-of-week from Monday through Friday:
       - name: GMAIL_DATA_PIPELINE_SCHEDULE_INTERVAL
         value: "0 7 * * 1-5"
       - name: CROSS_REF_IMPORT_SCHEDULE_INTERVAL
         value: "@daily"
+        # At minute 15 past every hour from 8 through 17 on every day-of-week from Monday through Friday:
       - name: GOOGLE_SPREADSHEET_SCHEDULE_INTERVAL
-        value: "0 */2 * * *" # Every 2 hour
+        value: "15 8-17/1 * * 1-5"
       - name: SEMANTIC_SCHOLAR_PIPELINE_SCHEDULE_INTERVAL
         value: "0 10 * * *" # At 10:00, every day
       - name: SEMANTIC_SCHOLAR_RECOMMENDATION_PIPELINE_SCHEDULE_INTERVAL


### PR DESCRIPTION
Updating schedule period of Google Spreadsheet Data Pipeline to "At minute 15 past every hour from 8 through 17 on every day-of-week from Monday through Friday."
cc: @fred-atherden @gnott 