### PR TITLE
Data Hub: Ingest Crossref metadata into OpenSearch (staging)

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -227,7 +227,12 @@ bigQueryToOpenSearch:
                       type: "nested"
                     full_text_list:
                       type: "nested"
+                crossref:
+                  properties:
+                    author_list:
+                      type: "nested"
     batchSize: 1000
+
   - dataPipelineId: bigquery_to_opensearch_preprints_v2_europepmc
     source:
       bigQuery:
@@ -321,6 +326,78 @@ bigQueryToOpenSearch:
         operationMode: 'update'
         upsert: True
     batchSize: 1000
+
+  - dataPipelineId: bigquery_to_opensearch_data_pipeline_crossref_metadata
+    source:
+      bigQuery:
+        projectName: 'elife-data-pipeline'
+        sqlQuery: |-
+          SELECT
+            crossref_response.DOI AS doi,
+
+            STRUCT(
+                crossref_response.imported_timestamp AS data_hub_imported_timestamp,
+                ARRAY_TO_STRING(crossref_response.title, '\n') AS title_with_markup,
+                crossref_response.abstract AS abstract_with_markup,
+                crossref_response.source AS source,
+                crossref_response.type AS type,
+                crossref_response.subtype AS subtype,
+                crossref_response.publisher AS publisher,
+                crossref_response.group_title AS group_title,
+
+                DATE(
+                  crossref_response.published.date_parts.year,
+                  crossref_response.published.date_parts.month,
+                  crossref_response.published.date_parts.day
+                ) AS publication_date,
+
+                crossref_response.published.date_parts.year AS publication_year,
+
+                ARRAY(
+                    SELECT AS STRUCT
+                        author.ORCID AS orcid,
+                        author.family AS family_name,
+                        author.given AS given_name,
+                        author.sequence AS sequence,
+                        author.suffix,
+                        ARRAY(
+                            SELECT affiliation.name
+                            FROM UNNEST(author.affiliation) AS affiliation
+                            WHERE affiliation.name IS NOT NULL
+                        ) AS affiliation_string_list
+                    FROM UNNEST(crossref_response.author) AS author
+                ) AS author_list
+            ) AS crossref
+
+          FROM `elife-data-pipeline.{ENV}.v_latest_crossref_metadata_api_response` AS crossref_response
+    fieldNamesFor:
+      id: doi
+      timestamp: crossref.data_hub_imported_timestamp
+    state:
+      initialState:
+        startTimestamp: '2024-02-01+00:00'
+      stateFile:
+        bucketName: '{ENV}-elife-data-pipeline'
+        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state-crossref.json'
+    target:
+      openSearch:
+        hostname: 'opensearch-staging'
+        port: 9200
+        timeout: 120
+        verifyCertificates: False
+        secrets:
+          parametersFromFile:
+            - parameterName: username
+              filePathEnvName: OPENSEARCH_USERNAME_FILE_PATH
+            - parameterName: password
+              filePathEnvName: OPENSEARCH_PASSWORD_FILE_PATH
+        indexName: 'preprints_v2'
+        updateIndexSettings: False
+        updateMappings: True
+        operationMode: 'update'
+        upsert: True
+    batchSize: 1000
+
   - dataPipelineId: bigquery_to_opensearch_preprints_v2_sciety
     source:
       bigQuery:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/854

This configures the ingestion of the Crossref metadata into OpenSearch.
Staging first, as there will need to be some Sciety Labs changes too.