### PR TITLE
Web API: Fixed SQL query due to removed line feeds

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -337,7 +337,7 @@ webApi:
       include:
         bigQuery:
           projectName: 'elife-data-pipeline'
-          sqlQuery:
+          sqlQuery: |-
             SELECT doi_prefix
             FROM UNNEST([
               '10.31730',  -- AfricArxiv


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/854

fix for #2622 

This was because the line feeds were removed and everything after the first comment became a comment too.