### PR TITLE
Web API: Enable provenance for Crossref pipeline

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -391,6 +391,7 @@ webApi:
           - 'date_time'  # this is after the record was processed
       recordProcessingSteps:
         - transform_crossref_api_date_parts
+      provenanceEnabled: True
 
   # bioRxiv/medRxiv MECA path metadata
   # http://api.biorxiv.org/meca_index/elife/help


### PR DESCRIPTION
part of elifesciences/data-hub-issues#854

Enabling provenance for Crossref pipeline allows us to see where the records came from (e.g. API url including the prefix used)

See https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1396