### PR TITLE
[#1026] feat: add build and start commands to epp-client in biophysics-colab deployment

### DIFF
--- a/deployments/epp/biophysics-colab/epp-client--biophysics-colab-kustomization.yaml
+++ b/deployments/epp/biophysics-colab/epp-client--biophysics-colab-kustomization.yaml
@@ -29,3 +29,21 @@ spec:
       epp_server: http://epp-server:3000
       iiif_server: https://biophysics-colab--epp.elifesciences.org/iiif
       disallow_robots: all
+  patches:
+    - target:
+        name: epp-client
+        kind: Deployment
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: epp-client
+        spec:
+          template:
+            spec:
+              containers:
+              - name: epp-client
+                command:
+                  - "sh"
+                  - "-c"
+                  - "yarn build && yarn start"

--- a/deployments/epp/biophysics-colab/epp-client--biophysics-colab-kustomization.yaml
+++ b/deployments/epp/biophysics-colab/epp-client--biophysics-colab-kustomization.yaml
@@ -15,6 +15,12 @@ spec:
   images:
     - name: ghcr.io/elifesciences/enhanced-preprints-client
       newTag: master-cfef2574-20240314.0511 # {"$imagepolicy": "epp--biophysics-colab:epp-client:tag"}
+  containers:
+    - name: epp-client
+      command:
+        - "sh"
+        - "-c"
+        - "yarn build && yarn start"
   postBuild:
     substitute:
       site_name: biophysics-colab

--- a/deployments/epp/biophysics-colab/epp-client--biophysics-colab-kustomization.yaml
+++ b/deployments/epp/biophysics-colab/epp-client--biophysics-colab-kustomization.yaml
@@ -15,12 +15,6 @@ spec:
   images:
     - name: ghcr.io/elifesciences/enhanced-preprints-client
       newTag: master-cfef2574-20240314.0511 # {"$imagepolicy": "epp--biophysics-colab:epp-client:tag"}
-  containers:
-    - name: epp-client
-      command:
-        - "sh"
-        - "-c"
-        - "yarn build && yarn start"
   postBuild:
     substitute:
       site_name: biophysics-colab


### PR DESCRIPTION
The epp-client container in the biophysics-colab deployment now includes commands for building and starting the application.