### PR TITLE
OpenSearch: Increased memory requests to 6 GB (in prod)

### DIFF
--- a/deployments/data-hub/opensearch/prod/cluster.yaml
+++ b/deployments/data-hub/opensearch/prod/cluster.yaml
@@ -20,10 +20,10 @@ spec:
     replicas: 3
     resources:
       requests:
-        memory: "4Gi"
+        memory: "6Gi"
         cpu: "1400m"
       limits:
-        memory: "4Gi"
+        memory: "6Gi"
     roles:
     - "data"
     - "cluster_manager"


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/905