### PR TITLE
Data Hub: CSV: Sciety Event: Removed executor_config

### DIFF
--- a/kustomizations/apps/data-hub-configs/s3-csv-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/s3-csv-data-pipeline.config.yaml
@@ -319,15 +319,3 @@ s3Csv:
     airflow:
       taskParameters:
         queue: 'kubernetes'
-        executor_config:
-          pod_override:
-            spec:
-              containers:
-                - name: 'base'
-                  resources:
-                    limits:
-                      memory: 1gb
-                      cpu: 1000m
-                    requests:
-                      memory: 1gb
-                      cpu: 100m


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/843

Due to error:

> Error rendering Kubernetes Pod Spec: Cannot convert a non-kubernetes.client.models.V1Pod object into a KubernetesExecutorConfig

![image](https://github.com/elifesciences/elife-flux-cluster/assets/1016473/884fc82b-7971-4ca7-a86e-e5a4d7928610)
