### PR TITLE
Data Hub: CSV Pipeline: Bring back pod_override

### DIFF
--- a/kustomizations/apps/data-hub-configs/s3-csv-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/s3-csv-data-pipeline.config.yaml
@@ -319,3 +319,15 @@ s3Csv:
     airflow:
       taskParameters:
         queue: 'kubernetes'
+        executor_config:
+          pod_override:
+            spec:
+              containers:
+                - name: 'base'
+                  resources:
+                    limits:
+                      memory: 1gb
+                      cpu: 1000m
+                    requests:
+                      memory: 1gb
+                      cpu: 100m


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/843

depends on https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1447