### PR TITLE
Data Hub: Web API: Configure tags for Hypothesis pipeline (public reviews)

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -85,6 +85,9 @@ webApi:
     airflow:
       dagParameters:
         schedule: '@hourly'
+        tags:
+          - 'Web API'
+          - 'DocMaps'
 
   # toggl api
   - dataPipelineId: toggl


### PR DESCRIPTION
Using tags could help filtering DAGs using the Airflow UI