### PR TITLE
Data Hub: Removed CSV and Web API schedule interval env variables

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -141,10 +141,6 @@ spec:
         value: "0 11 * * *" # At 11:00, every day
       - name: BIGQUERY_TO_OPENSEARCH_PIPELINE_SCHEDULE_INTERVAL
         value: "0 13 * * *" # At 13:00, every day
-      - name: WEB_API_SCHEDULE_INTERVAL
-        value: "25 2 * * *" # At 02:25
-      - name: S3_CSV_SCHEDULE_INTERVAL
-        value: "*/30 * * * *" # At every 30th minute
         # At minute 20 past every hour from 6 through 21 :
       - name: MONITOR_DATA_HUB_PIPELINE_HEALTH_SCHEDULE_INTERVAL
         value: "20 6-21/1 * * *"

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -146,11 +146,6 @@ spec:
         value: "0 11 * * *" # At 11:00, every day
       - name: BIGQUERY_TO_OPENSEARCH_PIPELINE_SCHEDULE_INTERVAL
         value: "0 13 * * *" # At 13:00, every day
-      - name: WEB_API_SCHEDULE_INTERVAL
-        value: "25 2 * * *" # At 02:25
-        # At minute 25 past every hour :
-      - name: S3_CSV_SCHEDULE_INTERVAL
-        value: "25 * * * *"
         # At minute 20 past every hour from 6 through 21 :
       - name: MONITOR_DATA_HUB_PIPELINE_HEALTH_SCHEDULE_INTERVAL
         value: "20 6-21/1 * * *"

--- a/deployments/data-hub/release-data-hub--test.yaml
+++ b/deployments/data-hub/release-data-hub--test.yaml
@@ -117,6 +117,7 @@ spec:
         value: "@daily"
       - name: SEMANTIC_SCHOLAR_PIPELINE_SCHEDULE_INTERVAL
         value: "0 10 * * *" # At 10:00, every day
+        # At minute 20 past every hour from 6 through 21 :
       - name: MONITOR_DATA_HUB_PIPELINE_HEALTH_SCHEDULE_INTERVAL
         value: "20 6-21/1 * * *"
       - name: MATERIALIZE_BIGQUERY_VIEWS_SCHEDULE_INTERVAL

--- a/deployments/data-hub/release-data-hub--test.yaml
+++ b/deployments/data-hub/release-data-hub--test.yaml
@@ -117,12 +117,6 @@ spec:
         value: "@daily"
       - name: SEMANTIC_SCHOLAR_PIPELINE_SCHEDULE_INTERVAL
         value: "0 10 * * *" # At 10:00, every day
-      - name: WEB_API_SCHEDULE_INTERVAL
-        value: "25 2 * * *" # At 02:25
-        # At minute 25 past every hour :
-      - name: S3_CSV_SCHEDULE_INTERVAL
-        value: "25 * * * *"
-        # At minute 20 past every hour from 6 through 21 :
       - name: MONITOR_DATA_HUB_PIPELINE_HEALTH_SCHEDULE_INTERVAL
         value: "20 6-21/1 * * *"
       - name: MATERIALIZE_BIGQUERY_VIEWS_SCHEDULE_INTERVAL


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/646

The schedule interval is now part of the yaml config instead.