### PR TITLE
Data Hub: GA UA: Increase pod memory to allow for more headroom

### DIFF
--- a/kustomizations/apps/data-hub-configs/ga-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/ga-data-pipeline.config.yaml
@@ -18,10 +18,10 @@ defaultConfig:
               - name: 'base'
                 resources:
                   limits:
-                    memory: 512Mi
+                    memory: 768Mi
                     cpu: 1000m
                   requests:
-                    memory: 512Mi
+                    memory: 768Mi
                     cpu: 100m
 
 # NOTE THAT there is a limit in the number of dimensions and metrics that can be requested


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/8759

The task was killed and with 450 MB base memory it was a bit close to the limit.