### PR TITLE
Data Hub: GA UA: Sciety date based config

### DIFF
--- a/kustomizations/apps/data-hub-configs/ga-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/ga-data-pipeline.config.yaml
@@ -648,3 +648,76 @@ googleAnalyticsPipelines:
     stateFile:
       bucketName: '{ENV}-elife-data-pipeline'
       objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/243656664/sciety_ga_universal_analytics_data_by_yearmonth_and_path_for_page_metrics_1.json'
+
+
+  # Sciety
+  # Dimensions: date + pagePath
+
+  - pipelineID: 'sciety_ga_universal_analytics_data_by_date_and_path_for_user_metrics_1'
+    defaultStartDate: "2021-01-01"
+    endDate: "2023-06-30"
+    batchDateInterval:
+      months: 1
+    dataset: '{ENV}'
+    table: 'ga_universal_analytics_data'
+    viewId: "243656664"  # "Sciety.org - Unfiltered"
+
+    dimensions:
+      - 'ga:date'
+      - 'ga:pagePath'
+    metrics:
+      - 'ga:users'
+      - 'ga:newUsers'
+      - 'ga:percentNewSessions'
+      - 'ga:sessionsPerUser'
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/243656664/sciety_ga_universal_analytics_data_by_date_and_path_for_user_metrics_1.json'
+
+  - pipelineID: 'sciety_ga_universal_analytics_data_by_date_and_path_for_session_metrics_1'
+    defaultStartDate: "2021-01-01"
+    endDate: "2023-06-30"
+    batchDateInterval:
+      months: 1
+    dataset: '{ENV}'
+    table: 'ga_universal_analytics_data'
+    viewId: "243656664"  # "Sciety.org - Unfiltered"
+
+    dimensions:
+      - 'ga:date'
+      - 'ga:pagePath'
+    metrics:
+      - 'ga:sessions'
+      - 'ga:bounces'
+      - 'ga:bounceRate'
+      - 'ga:sessionDuration'
+      - 'ga:avgSessionDuration'
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/243656664/sciety_ga_universal_analytics_data_by_date_and_path_for_session_metrics_1.json'
+
+  - pipelineID: 'sciety_ga_universal_analytics_data_by_date_and_path_for_page_metrics_1'
+    defaultStartDate: "2021-01-01"
+    endDate: "2023-06-30"
+    batchDateInterval:
+      months: 1
+    dataset: '{ENV}'
+    table: 'ga_universal_analytics_data'
+    viewId: "243656664"  # "Sciety.org - Unfiltered"
+
+    dimensions:
+      - 'ga:date'
+      - 'ga:pagePath'
+    metrics:
+      - 'ga:entrances'
+      - 'ga:entranceRate'
+      - 'ga:pageviews'
+      - 'ga:pageviewsPerSession'
+      - 'ga:uniquePageviews'
+      - 'ga:timeOnPage'
+      - 'ga:avgTimeOnPage'
+      - 'ga:exits'
+      - 'ga:exitRate'
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/243656664/sciety_ga_universal_analytics_data_by_date_and_path_for_page_metrics_1.json'

--- a/kustomizations/apps/data-hub-configs/ga-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/ga-data-pipeline.config.yaml
@@ -651,6 +651,76 @@ googleAnalyticsPipelines:
 
 
   # Sciety
+  # Dimensions: date
+
+  - pipelineID: 'sciety_ga_universal_analytics_data_by_date_for_user_metrics_1'
+    defaultStartDate: "2021-01-01"
+    endDate: "2023-06-30"
+    batchDateInterval:
+      months: 1
+    dataset: '{ENV}'
+    table: 'ga_universal_analytics_data'
+    viewId: "243656664"  # "Sciety.org - Unfiltered"
+
+    dimensions:
+      - 'ga:date'
+    metrics:
+      - 'ga:users'
+      - 'ga:newUsers'
+      - 'ga:percentNewSessions'
+      - 'ga:sessionsPerUser'
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/243656664/sciety_ga_universal_analytics_data_by_date_for_user_metrics_1.json'
+
+  - pipelineID: 'sciety_ga_universal_analytics_data_by_date_for_session_metrics_1'
+    defaultStartDate: "2021-01-01"
+    endDate: "2023-06-30"
+    batchDateInterval:
+      months: 1
+    dataset: '{ENV}'
+    table: 'ga_universal_analytics_data'
+    viewId: "243656664"  # "Sciety.org - Unfiltered"
+
+    dimensions:
+      - 'ga:date'
+    metrics:
+      - 'ga:sessions'
+      - 'ga:bounces'
+      - 'ga:bounceRate'
+      - 'ga:sessionDuration'
+      - 'ga:avgSessionDuration'
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/243656664/sciety_ga_universal_analytics_data_by_date_for_session_metrics_1.json'
+
+  - pipelineID: 'sciety_ga_universal_analytics_data_by_date_for_page_metrics_1'
+    defaultStartDate: "2021-01-01"
+    endDate: "2023-06-30"
+    batchDateInterval:
+      months: 1
+    dataset: '{ENV}'
+    table: 'ga_universal_analytics_data'
+    viewId: "243656664"  # "Sciety.org - Unfiltered"
+
+    dimensions:
+      - 'ga:date'
+    metrics:
+      - 'ga:entrances'
+      - 'ga:entranceRate'
+      - 'ga:pageviews'
+      - 'ga:pageviewsPerSession'
+      - 'ga:uniquePageviews'
+      - 'ga:timeOnPage'
+      - 'ga:avgTimeOnPage'
+      - 'ga:exits'
+      - 'ga:exitRate'
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/243656664/sciety_ga_universal_analytics_data_by_date_for_page_metrics_1.json'
+
+
+  # Sciety
   # Dimensions: date + pagePath
 
   - pipelineID: 'sciety_ga_universal_analytics_data_by_date_and_path_for_user_metrics_1'


### PR DESCRIPTION
Related to https://github.com/elifesciences/issues/issues/8759

Some Yeam Month based Sciety metrics seem to be skewed for some months. Perhaps due to bots.
Retrieving daily data seems to be useful for that reason.