### PR TITLE
Data Hub: GA UA: journal date only config (no additional dimension)

### DIFF
--- a/kustomizations/apps/data-hub-configs/ga-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/ga-data-pipeline.config.yaml
@@ -451,6 +451,75 @@ googleAnalyticsPipelines:
       objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/93573727/ga_universal_analytics_data_by_yearmonth_and__channelgrouping_and_source_medium_and_campaign_and_path_and_title_and_event_category_action_label_for_event_and_basic_page_session_and_user_metrics_1.json'
 
 
+  # Dimensions: date
+
+  - pipelineID: 'ga_universal_analytics_data_by_date_for_user_metrics_1'
+    defaultStartDate: "2014-11-01"
+    endDate: "2023-06-30"
+    batchDateInterval:
+      months: 1
+    dataset: '{ENV}'
+    table: 'ga_universal_analytics_data'
+    viewId: "93573727"  # "Web traffic excluding eLife IP"
+
+    dimensions:
+      - 'ga:date'
+    metrics:
+      - 'ga:users'
+      - 'ga:newUsers'
+      - 'ga:percentNewSessions'
+      - 'ga:sessionsPerUser'
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/93573727/ga_universal_analytics_data_by_date_for_user_metrics_1.json'
+
+  - pipelineID: 'ga_universal_analytics_data_by_date_for_session_metrics_1'
+    defaultStartDate: "2014-11-01"
+    endDate: "2023-06-30"
+    batchDateInterval:
+      months: 1
+    dataset: '{ENV}'
+    table: 'ga_universal_analytics_data'
+    viewId: "93573727"  # "Web traffic excluding eLife IP"
+
+    dimensions:
+      - 'ga:date'
+    metrics:
+      - 'ga:sessions'
+      - 'ga:bounces'
+      - 'ga:bounceRate'
+      - 'ga:sessionDuration'
+      - 'ga:avgSessionDuration'
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/93573727/ga_universal_analytics_data_by_date_for_session_metrics_1.json'
+
+  - pipelineID: 'ga_universal_analytics_data_by_date_for_page_metrics_1'
+    defaultStartDate: "2014-11-01"
+    endDate: "2023-06-30"
+    batchDateInterval:
+      months: 1
+    dataset: '{ENV}'
+    table: 'ga_universal_analytics_data'
+    viewId: "93573727"  # "Web traffic excluding eLife IP"
+
+    dimensions:
+      - 'ga:date'
+    metrics:
+      - 'ga:entrances'
+      - 'ga:entranceRate'
+      - 'ga:pageviews'
+      - 'ga:pageviewsPerSession'
+      - 'ga:uniquePageviews'
+      - 'ga:timeOnPage'
+      - 'ga:avgTimeOnPage'
+      - 'ga:exits'
+      - 'ga:exitRate'
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/ga-universal-analytics/state/by-view-id/93573727/ga_universal_analytics_data_by_date_for_page_metrics_1.json'
+
+
   # Dimensions: date + pagePath
 
   - pipelineID: 'ga_universal_analytics_data_by_date_and_path_for_user_metrics_1'


### PR DESCRIPTION
related to https://github.com/elifesciences/issues/issues/8759

We already have date and pagePath dimensions.
We also have a config for the yearMonth dimension. This adds a config for just he date as a dimension (without additional dimension fields).