### PR TITLE
Update new-application-team.md document to help setup a writable repo if required

### DIFF
--- a/docs/new-application-team.md
+++ b/docs/new-application-team.md
@@ -9,9 +9,12 @@ Application teams are empowered to deploy, run, and maintain their own software 
 ## Checklist
 
 1. Decide on a reserved Kubernetes namespace e.g. `sciety`.
-1. Create a [Github repository](https://github.com/sciety/deployment) that will contain definitions for all Kubernetes resources.
-1. Sync this repository by adding [a Kustomization](/clusters/flux-prod/sciety-team/).
-1. Create a [dedicated node pool](/nodes/clusters/flux-prod/nodepools) that will host all workloads in a certain namespace.
+1. Create a [Github repository](https://github.com/sciety/deployment) that will contain definitions for all Kubernetes resources. Optionally [create a deploy key](https://fluxcd.io/flux/cmd/flux_create_secret_git/) and add to this repository in github.
+1. Sync this repository by adding [a Kustomization for the team](/teams/sciety/), and [a Flux Kustomization](/clusters/flux-prod/sciety-team.yaml).
+1. In the kustomizations, create (as needed): 
+    1. Create a [dedicated node pool](/teams/sciety/nodepool.yaml) that will host all workloads in a certain namespace.
+    1. Create a [dedicated storage class](/teams/sciety/storageclass.yaml) that will configure and tag storage for a namespace.
+    1. Create a deployment [sync object](/teams/sciety/deployment-sync.yaml) for the git repository created above, referencing the deploy key secret if created above
 1. Test the setup via the creation of the desired [Kubernetes namespace](https://github.com/sciety/deployment/blob/main/manifests/namespace.yaml). **Note:** Make sure to set the annotation to assign workloads to the correct nodepool:
     ```
     apiVersion: v1


### PR DESCRIPTION
After working through an issue with basex-validator not writing updates back, I have updated the documentation to make reference to creating a deployment key secret and how/when to reference it.

While there, I've corrected a few other out of date descriptions and paths.