### PR TITLE
Rollbacked KubernetesExecutor from CSV pipelines

### DIFF
--- a/kustomizations/apps/data-hub-configs/s3-csv-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/s3-csv-data-pipeline.config.yaml
@@ -10,20 +10,20 @@ defaultConfig:
       schedule: '*/30 * * * *'  # At every 30th minute
       tags:
         - 'CSV'
-    taskParameters:
-      queue: 'kubernetes'
-      executor_config:
-        pod_override:
-          spec:
-            containers:
-              - name: 'base'
-                resources:
-                  limits:
-                    memory: 1Gi
-                    cpu: 1000m
-                  requests:
-                    memory: 1Gi
-                    cpu: 100m
+    # taskParameters:
+    #   queue: 'kubernetes'
+    #   executor_config:
+    #     pod_override:
+    #       spec:
+    #         containers:
+    #           - name: 'base'
+    #             resources:
+    #               limits:
+    #                 memory: 1Gi
+    #                 cpu: 1000m
+    #               requests:
+    #                 memory: 1Gi
+    #                 cpu: 100m
 
 s3Csv:
   - dataPipelineId: rp_reviews_and_elife_assessment_emails
@@ -404,3 +404,17 @@ s3Csv:
       objectName: "airflow-config/s3-csv/{ENV}-state/sciety_events.json"
     recordProcessingSteps:
       - parse_json_value
+    taskParameters:
+      queue: 'kubernetes'
+      executor_config:
+        pod_override:
+          spec:
+            containers:
+              - name: 'base'
+                resources:
+                  limits:
+                    memory: 1Gi
+                    cpu: 1000m
+                  requests:
+                    memory: 1Gi
+                    cpu: 100m


### PR DESCRIPTION
Currently we are facing memory issues because of not individually adjusted memory usege for kubernetesExecutor pods. For now we are changing it back to Celery Executor.