### PR TITLE
KubernetesExecutor config added back for CSV pipeline

### DIFF
--- a/kustomizations/apps/data-hub-configs/s3-csv-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/s3-csv-data-pipeline.config.yaml
@@ -10,20 +10,20 @@ defaultConfig:
       schedule: '*/30 * * * *'  # At every 30th minute
       tags:
         - 'CSV'
-    # taskParameters:
-    #   queue: 'kubernetes'
-    #   executor_config:
-    #     pod_override:
-    #       spec:
-    #         containers:
-    #           - name: 'base'
-    #             resources:
-    #               limits:
-    #                 memory: 1Gi
-    #                 cpu: 1000m
-    #               requests:
-    #                 memory: 1Gi
-    #                 cpu: 100m
+    taskParameters:
+      queue: 'kubernetes'
+      executor_config:
+        pod_override:
+          spec:
+            containers:
+              - name: 'base'
+                resources:
+                  limits:
+                    memory: 1Gi
+                    cpu: 1000m
+                  requests:
+                    memory: 1Gi
+                    cpu: 100m
 
 s3Csv:
   - dataPipelineId: rp_reviews_and_elife_assessment_emails
@@ -404,18 +404,3 @@ s3Csv:
       objectName: "airflow-config/s3-csv/{ENV}-state/sciety_events.json"
     recordProcessingSteps:
       - parse_json_value
-    airflow:
-      taskParameters:
-        queue: 'kubernetes'
-        executor_config:
-          pod_override:
-            spec:
-              containers:
-                - name: 'base'
-                  resources:
-                    limits:
-                      memory: 1Gi
-                      cpu: 1000m
-                    requests:
-                      memory: 1Gi
-                      cpu: 100m


### PR DESCRIPTION
following from this fix: https://github.com/elifesciences/data-science-dags/pull/636

And it seems sciety_events pod now only using the defined one in CSV config which is 1Gi.

<img width="1413" alt="Screenshot 2024-07-17 at 14 49 02" src="https://github.com/user-attachments/assets/9fb2ae7b-5fa8-477e-b4e1-50f1a0db8df1">
