### PR TITLE
Data Hub: EuropePMC LabsLink: Change schedule to hourly

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -126,7 +126,7 @@ spec:
       - name: EUROPEPMC_PIPELINE_SCHEDULE_INTERVAL
         value: "0 6 * * *" # At 06:00, every day
       - name: EUROPEPMC_LABSLNK_PIPELINE_SCHEDULE_INTERVAL
-        value: "0 10 * * *" # At 10:00, every day
+        value: "10 * * * *" # 40 past the hour, every day
         # At 07:00 on every day-of-week from Monday through Friday :
       - name: GMAIL_DATA_PIPELINE_SCHEDULE_INTERVAL
         value: "0 7 * * 1-5"

--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -126,7 +126,7 @@ spec:
       - name: EUROPEPMC_PIPELINE_SCHEDULE_INTERVAL
         value: "0 6 * * *" # At 06:00, every day
       - name: EUROPEPMC_LABSLNK_PIPELINE_SCHEDULE_INTERVAL
-        value: "10 * * * *" # 40 past the hour, every day
+        value: "40 * * * *" # 40 past the hour, every day
         # At 07:00 on every day-of-week from Monday through Friday :
       - name: GMAIL_DATA_PIPELINE_SCHEDULE_INTERVAL
         value: "0 7 * * 1-5"

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -131,7 +131,7 @@ spec:
       - name: EUROPEPMC_PIPELINE_SCHEDULE_INTERVAL
         value: "0 6 * * *" # At 06:00, every day
       - name: EUROPEPMC_LABSLNK_PIPELINE_SCHEDULE_INTERVAL
-        value: "10 * * * *" # 40 past the hour, every day
+        value: "40 * * * *" # 40 past the hour, every day
         # At 07:00 on every day-of-week from Monday through Friday:
       - name: GMAIL_DATA_PIPELINE_SCHEDULE_INTERVAL
         value: "0 7 * * 1-5"

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -131,7 +131,7 @@ spec:
       - name: EUROPEPMC_PIPELINE_SCHEDULE_INTERVAL
         value: "0 6 * * *" # At 06:00, every day
       - name: EUROPEPMC_LABSLNK_PIPELINE_SCHEDULE_INTERVAL
-        value: "0 10 * * *" # At 10:00, every day
+        value: "10 * * * *" # 40 past the hour, every day
         # At 07:00 on every day-of-week from Monday through Friday:
       - name: GMAIL_DATA_PIPELINE_SCHEDULE_INTERVAL
         value: "0 7 * * 1-5"


### PR DESCRIPTION
This is to improve evaluated only search delay.
We believe EuropePMC is reading LabsLink in the evening, but it could be any time. We are now updating Sciety data hourly.
So running it hourly would make sense.
(The CSV import should be finished 40 past the hour)

The LabsLink pipeline itself only takes a few seconds. It does currently build up the whole XML structure in memory.