### PR TITLE
Data Hub: OpenSearch: Configured ingest pipelines (Staging)

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -430,6 +430,10 @@ bigQueryToOpenSearch:
             properties:
                 doi:
                   type: "text"
+                calculated:
+                  properties:
+                    doi_prefix:
+                      type: "keyword"
                 s2:
                   properties:
                     author_list:

--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -59,6 +59,363 @@ bigQueryToOpenSearch:
         updateMappings: True
         operationMode: 'update'
         upsert: True
+        ingestPipelines:
+          - name: preprints_v2_doi_prefix_pipeline
+            definition: |-
+              {
+                "description": "Extracts doi_prefix from doi",
+                "processors": [
+                  {
+                    "grok": {
+                      "field": "doi",
+                      "patterns": ["^(?<calculated.doi_prefix>[^/]+)/.*$"]
+                    }
+                  }
+                ]
+              }
+            tests:
+              - description: "Should extract doi_prefix from doi"
+                inputDocument: |-
+                  {
+                    "doi": "10.1234/doi_1"
+                  }
+                expectedDocument: |-
+                  {
+                    "doi": "10.1234/doi_1",
+                    "calculated": {
+                      "doi_prefix": "10.1234"
+                    }
+                  }
+          - name: preprints_v2_publication_date_pipeline
+            definition: |-
+              {
+                "description": "Sets calculated.publication_date from crossref or europepmc",
+                "processors": [
+                  {
+                    "remove": {
+                      "field": "calculated.publication_date",
+                      "if": "ctx.calculated?.publication_date != null"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.publication_date == null && ctx.crossref?.publication_date != null",
+                      "field": "calculated.publication_date",
+                      "value": "{{crossref.publication_date}}"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.publication_date == null && ctx.europepmc?.first_publication_date != null",
+                      "field": "calculated.publication_date",
+                      "value": "{{europepmc.first_publication_date}}"
+                    }
+                  }
+                ]
+              }
+            tests:
+              - description: "Should remove existing calculated field"
+                inputDocument: |-
+                  {
+                    "calculated": {
+                      "publication_date": "2001-02-03"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "calculated": {
+                    }
+                  }
+              - description: "Should prefer publication date from Crossref over EuropePMC"
+                inputDocument: |-
+                  {
+                    "crossref": {
+                      "publication_date": "2001-01-01"
+                    },
+                    "europepmc": {
+                      "first_publication_date": "2001-01-02"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "crossref": {
+                      "publication_date": "2001-01-01"
+                    },
+                    "europepmc": {
+                      "first_publication_date": "2001-01-02"
+                    },
+                    "calculated": {
+                      "publication_date": "2001-01-01"
+                    }
+                  }
+              - description: "Should fallback to publication date from EuropePMC"
+                inputDocument: |-
+                  {
+                    "europepmc": {
+                      "first_publication_date": "2001-02-03"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "europepmc": {
+                      "first_publication_date": "2001-02-03"
+                    },
+                    "calculated": {
+                      "publication_date": "2001-02-03"
+                    }
+                  }
+          - name: preprints_v2_title_with_markup_pipeline
+            definition: |-
+              {
+                "description": "Sets calculated.title_with_markup from crossref or europepmc or s2",
+                "processors": [
+                  {
+                    "remove": {
+                      "field": "calculated.title_with_markup",
+                      "if": "ctx.calculated?.title_with_markup != null"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.title_with_markup == null && ctx.crossref?.title_with_markup != null",
+                      "field": "calculated.title_with_markup",
+                      "value": "{{crossref.title_with_markup}}"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.title_with_markup == null && ctx.europepmc?.title_with_markup != null",
+                      "field": "calculated.title_with_markup",
+                      "value": "{{europepmc.title_with_markup}}"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.title_with_markup == null && ctx.s2?.title != null",
+                      "field": "calculated.title_with_markup",
+                      "value": "{{s2.title}}"
+                    }
+                  }
+                ]
+              }
+            tests:
+              - description: "Should remove existing calculated field"
+                inputDocument: |-
+                  {
+                    "calculated": {
+                      "title_with_markup": "Title 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "calculated": {
+                    }
+                  }
+              - description: "Should prefer title from Crossref over EuropePM and S2"
+                inputDocument: |-
+                  {
+                    "crossref": {
+                      "title_with_markup": "Crossref Title 1"
+                    },
+                    "europepmc": {
+                      "title_with_markup": "EuropePMC Title 1"
+                    },
+                    "s2": {
+                      "title": "S2 Title 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "crossref": {
+                      "title_with_markup": "Crossref Title 1"
+                    },
+                    "europepmc": {
+                      "title_with_markup": "EuropePMC Title 1"
+                    },
+                    "s2": {
+                      "title": "S2 Title 1"
+                    },
+                    "calculated": {
+                      "title_with_markup": "Crossref Title 1"
+                    }
+                  }
+              - description: "Should prefer title from EuropePMC over S2"
+                inputDocument: |-
+                  {
+                    "europepmc": {
+                      "title_with_markup": "EuropePMC Title 1"
+                    },
+                    "s2": {
+                      "title": "S2 Title 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "europepmc": {
+                      "title_with_markup": "EuropePMC Title 1"
+                    },
+                    "s2": {
+                      "title": "S2 Title 1"
+                    },
+                    "calculated": {
+                      "title_with_markup": "EuropePMC Title 1"
+                    }
+                  }
+              - description: "Should fallback to title from s2"
+                inputDocument: |-
+                  {
+                    "s2": {
+                      "title": "S2 Title 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "s2": {
+                      "title": "S2 Title 1"
+                    },
+                    "calculated": {
+                      "title_with_markup": "S2 Title 1"
+                    }
+                  }
+          - name: preprints_v2_abstract_with_markup_pipeline
+            definition: |-
+              {
+                "description": "Sets calculated.abstract_with_markup from crossref or europepmc or s2",
+                "processors": [
+                  {
+                    "remove": {
+                      "field": "calculated.abstract_with_markup",
+                      "if": "ctx.calculated?.abstract_with_markup != null"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.abstract_with_markup == null && ctx.crossref?.abstract_with_markup != null",
+                      "field": "calculated.abstract_with_markup",
+                      "value": "{{crossref.abstract_with_markup}}"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.abstract_with_markup == null && ctx.europepmc?.abstract_with_markup != null",
+                      "field": "calculated.abstract_with_markup",
+                      "value": "{{europepmc.abstract_with_markup}}"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.abstract_with_markup == null && ctx.s2?.abstract != null",
+                      "field": "calculated.abstract_with_markup",
+                      "value": "{{s2.abstract}}"
+                    }
+                  }
+                ]
+              }
+            tests:
+              - description: "Should remove existing calculated field"
+                inputDocument: |-
+                  {
+                    "calculated": {
+                      "abstract_with_markup": "Abstract 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "calculated": {
+                    }
+                  }
+              - description: "Should prefer abstract from Crossref over EuropePMC and S2"
+                inputDocument: |-
+                  {
+                    "crossref": {
+                      "abstract_with_markup": "Crossref Abstract 1"
+                    },
+                    "europepmc": {
+                      "abstract_with_markup": "EuropePMC Abstract 1"
+                    },
+                    "s2": {
+                      "title": "S2 Abstract 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "crossref": {
+                      "abstract_with_markup": "Crossref Abstract 1"
+                    },
+                    "europepmc": {
+                      "abstract_with_markup": "EuropePMC Abstract 1"
+                    },
+                    "s2": {
+                      "title": "S2 Abstract 1"
+                    },
+                    "calculated": {
+                      "abstract_with_markup": "Crossref Abstract 1"
+                    }
+                  }
+              - description: "Should prefer abstract from EuropePMC over S2"
+                inputDocument: |-
+                  {
+                    "europepmc": {
+                      "abstract_with_markup": "EuropePMC Abstract 1"
+                    },
+                    "s2": {
+                      "title": "S2 Abstract 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "europepmc": {
+                      "abstract_with_markup": "EuropePMC Abstract 1"
+                    },
+                    "s2": {
+                      "title": "S2 Abstract 1"
+                    },
+                    "calculated": {
+                      "abstract_with_markup": "EuropePMC Abstract 1"
+                    }
+                  }
+              - description: "Should fallback to abstract from S2"
+                inputDocument: |-
+                  {
+                    "s2": {
+                      "abstract": "S2 Abstract 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "s2": {
+                      "abstract": "S2 Abstract 1"
+                    },
+                    "calculated": {
+                      "abstract_with_markup": "S2 Abstract 1"
+                    }
+                  }
+          - name: preprints_v2_default_pipeline
+            definition: |-
+              {
+                "processors": [
+                  {
+                    "pipeline": {
+                      "name": "preprints_v2_doi_prefix_pipeline"
+                    }
+                  },
+                  {
+                    "pipeline": {
+                      "name": "preprints_v2_publication_date_pipeline"
+                    }
+                  },
+                  {
+                    "pipeline": {
+                      "name": "preprints_v2_title_with_markup_pipeline"
+                    }
+                  },
+                  {
+                    "pipeline": {
+                      "name": "preprints_v2_abstract_with_markup_pipeline"
+                    }
+                  }
+                ]
+              }
         indexSettings:
           # Note: These settings can usually only be applied to a new index.
           #   It is important to set for example the "knn_vector" fields ahead of time.
@@ -68,6 +425,7 @@ bigQueryToOpenSearch:
               # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
               knn: True
               "knn.algo_param.ef_search": 512
+              default_pipeline: 'preprints_v2_default_pipeline'
           mappings:
             properties:
                 doi:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/963

This adds ingest pipelines to calculate the following `calculated` fields:

- `doi_prefix` (extracted from `doi`)
- `publication_date` (select from `crossref` or `europepmc`)
- `title_with_markup` (select from `crossref`, `europepmc` or `s2`)
- `abstract_with_markup` (select from `crossref`, `europepmc` or `s2`)

This will allow us to just search over the `calculated` fields.

Depends on https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1491

Depends on https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1492