### PR TITLE
OpenSearch: enabled `ingest` role (Staging)

### DIFF
--- a/deployments/data-hub/opensearch/staging/cluster.yaml
+++ b/deployments/data-hub/opensearch/staging/cluster.yaml
@@ -35,6 +35,7 @@ spec:
     roles:
     - "data"
     - "cluster_manager"
+    - "ingest"
     diskSize: 60Gi
     persistence:
       pvc:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/963

This is necessary to make use of the newly configured ingest pipelines (via #2911).

Trying to apply the ingest pipeline failed.

```http
POST preprints_v2/_update_by_query?pipeline=preprints_v2_default_pipeline
```

```json
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_state_exception",
        "reason": "There are no ingest nodes in this cluster, unable to forward request to an ingest node."
      }
    ],
    "type": "illegal_state_exception",
    "reason": "There are no ingest nodes in this cluster, unable to forward request to an ingest node."
  },
  "status": 500
}
```