### PR TITLE
Data Hub: OpenSearch: Convert S2 doi to lower case to avoid issues

### DIFF
--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--prod.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--prod.yaml
@@ -6,7 +6,7 @@ bigQueryToOpenSearch:
         projectName: 'elife-data-pipeline'
         sqlQuery: |-
           SELECT
-              s2_response.externalIds.DOI AS doi,
+              LOWER(s2_response.externalIds.DOI) AS doi,
 
               STRUCT(
                 s2_response.provenance.imported_timestamp AS data_hub_imported_timestamp,

--- a/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
+++ b/kustomizations/apps/data-hub-configs/bigquery-to-opensearch--stg.yaml
@@ -6,7 +6,7 @@ bigQueryToOpenSearch:
         projectName: 'elife-data-pipeline'
         sqlQuery: |-
           SELECT
-              s2_response.externalIds.DOI AS doi,
+              LOWER(s2_response.externalIds.DOI) AS doi,
 
               STRUCT(
                 s2_response.provenance.imported_timestamp AS data_hub_imported_timestamp,


### PR DESCRIPTION
Somewhat related to: https://github.com/elifesciences/data-hub-issues/issues/963

There are a few upper case DOIs in S2.
And as it happened, all version conflcts while applying the ingest pipeline had uppercase DOIs.