### PR TITLE
OpenSearch: Increased disk size (staging)

### DIFF
--- a/deployments/data-hub/opensearch/staging/cluster.yaml
+++ b/deployments/data-hub/opensearch/staging/cluster.yaml
@@ -36,7 +36,7 @@ spec:
     - "data"
     - "cluster_manager"
     - "ingest"
-    diskSize: 60Gi
+    diskSize: 200Gi
     persistence:
       pvc:
         storageClass: csi-ebs-gp3


### PR DESCRIPTION
Related to https://github.com/elifesciences/data-hub-issues/issues/963

Currently the index seem to be 91 GB in size. Although it may be able to shrink somehow if it removed deleted documents.