### PR TITLE
Data Hub: K8s pipeline: Configure deployment env

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline.config.yaml
@@ -10,6 +10,8 @@ kubernetesPipelines:
       - '-m'
       - 'data_pipeline.elife_article_xml.cli'
     env:
+      - name: DEPLOYMENT_ENV
+        value: staging
       - name: ELIFE_ARTICLE_XML_CONFIG_FILE_PATH
         value: /dag_config_files/elife-article-xml.config.yaml
       - name: GITHUB_API_AUTHORIZATION_FILE_PATH


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/961

It is currently falling back to the `ci` deployment env.
This sets it to `staging`. Although ideally we could inherit the deployment env.