### PR TITLE
Data Hub: K8s: Increase resources for Data Science pipeline

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
@@ -1538,8 +1538,9 @@ kubernetesPipelines:
           secretName: gcloud
     resources:
       limits:
-        memory: 600Mi
-        cpu: 1000m
+        memory: 6459Mi
+        cpu: 1700m
       requests:
-        memory: 500Mi
-        cpu: 100m
+        memory: 6459Mi
+        cpu: 1495m
+        ephemeral-storage: 10Gi


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/965

We ran out of memory for the lower limits.
This is now using the default values for the KubernetesExecutor.
We will decrease the resources after we are able to measure the actual usage.