### PR TITLE
Data Hub: K8s: Data Science Dags: Remove AIRFLOW_APPLICATIONS_DIRECTORY_PATH

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
@@ -1520,8 +1520,6 @@ kubernetesPipelines:
         value: /dag_secret_files/gcloud/credentials.json
       - name: AWS_CONFIG_FILE
         value: /dag_secret_files/aws/credentials
-      - name: AIRFLOW_APPLICATIONS_DIRECTORY_PATH
-        value: /opt/airflow/auxiliary_data_pipeline_files
     volumeMounts:
       - name: gcloud-secret-volume
         mountPath: /dag_secret_files/gcloud/


### PR DESCRIPTION
part of AIRFLOW_APPLICATIONS_DIRECTORY_PATH

The environment variable points to path in our combined Airflow image.
For the `data-science-dags` image, the `notebooks` are within the working directory and it should find it automatically.

Alternatively we could set `AIRFLOW_APPLICATIONS_DIRECTORY_PATH` to the working directory.