### PR TITLE
Data Hub: K8s: Data Science DAGs: Set AIRFLOW_APPLICATIONS_DIRECTORY_PATH to working directory

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
@@ -1520,6 +1520,8 @@ kubernetesPipelines:
         value: /dag_secret_files/gcloud/credentials.json
       - name: AWS_CONFIG_FILE
         value: /dag_secret_files/aws/credentials
+      - name: AIRFLOW_APPLICATIONS_DIRECTORY_PATH
+        value: /opt/airflow
     volumeMounts:
       - name: gcloud-secret-volume
         mountPath: /dag_secret_files/gcloud/


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/965

follow up to #3024

Removing the environment variable still failed because our image is setting the environment variable to `$AIRFLOW_HOME/applications_file_directory` (that is where it also placed the example notebook)

$AIRFLOW_HOME is `/opt/airflow`.
Setting `AIRFLOW_APPLICATIONS_DIRECTORY_PATH` to the working directory (`/opt/airflow`) should find the notebooks underneath it.