### PR TITLE
Data Hub: K8s: Data Science DAGs: Reduce memory requirements

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
@@ -1538,9 +1538,8 @@ kubernetesPipelines:
           secretName: gcloud
     resources:
       limits:
-        memory: 6459Mi
-        cpu: 1700m
+        memory: 1Gi
+        cpu: 1000m
       requests:
-        memory: 6459Mi
-        cpu: 1495m
-        ephemeral-storage: 10Gi
+        memory: 1Gi
+        cpu: 100m


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/965

We observed memory usage of around 800 MB.
CPU usage appeared to be around 0.134.