### PR TITLE
Data Hub: K8s: Data Science DAGs: Increase to 2Gi due to OOM

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
@@ -1538,8 +1538,8 @@ kubernetesPipelines:
           secretName: gcloud
     resources:
       limits:
-        memory: 1Gi
+        memory: 2Gi
         cpu: 1000m
       requests:
-        memory: 1Gi
+        memory: 2Gi
         cpu: 100m


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/965

follow up to: #3026

Encountered OOM with just 1Gi (even though the charts showed lower usage).

> staging-data-science-peerscout-build-reviewing-editor-profiles-kubernet-3vuqxdbq   0/1     OOMKilled   0               7m13s