### PR TITLE
Data Hub: K8s: Data Science DAGs: Removed AIRFLOW_APPLICATIONS_DIRECTORY_PATH again after updating data-science-dags image

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
@@ -1520,8 +1520,6 @@ kubernetesPipelines:
         value: /dag_secret_files/gcloud/credentials.json
       - name: AWS_CONFIG_FILE
         value: /dag_secret_files/aws/credentials
-      - name: AIRFLOW_APPLICATIONS_DIRECTORY_PATH
-        value: /opt/airflow
     volumeMounts:
       - name: gcloud-secret-volume
         mountPath: /dag_secret_files/gcloud/


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/965