### PR TITLE
Data Hub API: Limit concurrent connections by IP to 3

### DIFF
--- a/deployments/data-hub/data-hub-api/data-hub-api--prod.yaml
+++ b/deployments/data-hub/data-hub-api/data-hub-api--prod.yaml
@@ -93,6 +93,7 @@ metadata:
   labels:
     app: data-hub-api--prod
   annotations:
+    nginx.ingress.kubernetes.io/limit-connections: "3"
     nginx.ingress.kubernetes.io/limit-rps: "3"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
 spec:

--- a/deployments/data-hub/data-hub-api/data-hub-api--stg.yaml
+++ b/deployments/data-hub/data-hub-api/data-hub-api--stg.yaml
@@ -95,6 +95,7 @@ metadata:
   labels:
     app: data-hub-api--stg
   annotations:
+    nginx.ingress.kubernetes.io/limit-connections: "3"
     nginx.ingress.kubernetes.io/limit-rps: "3"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
 spec:


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/994

It seems all of those settings are per IP address.
Maybe we could remove `limit-rps`.

Ideally there would could limit the number of concurrent connections irrespective of the IP.

[Documentation](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#rate-limiting)

These annotations define limits on connections and transmission rates. These can be used to mitigate [DDoS Attacks](https://www.nginx.com/blog/mitigating-ddos-attacks-with-nginx-and-nginx-plus).

> - nginx.ingress.kubernetes.io/limit-connections: number of concurrent connections allowed from a single IP address. A 503 error is returned when exceeding this limit.
> - nginx.ingress.kubernetes.io/limit-rps: number of requests accepted from a given IP each second. The burst limit is set to this limit multiplied by the burst multiplier, the default multiplier is 5. When clients exceed this limit, [limit-req-status-code](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#limit-req-status-code) default: 503 is returned.
> - nginx.ingress.kubernetes.io/limit-rpm: number of requests accepted from a given IP each minute. The burst limit is set to this limit multiplied by the burst multiplier, the default multiplier is 5. When clients exceed this limit, [limit-req-status-code](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#limit-req-status-code) default: 503 is returned.
> - nginx.ingress.kubernetes.io/limit-burst-multiplier: multiplier of the limit rate for burst size. The default burst multiplier is 5, this annotation override the default multiplier. When clients exceed this limit, [limit-req-status-code](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#limit-req-status-code) default: 503 is returned.
> - nginx.ingress.kubernetes.io/limit-rate-after: initial number of kilobytes after which the further transmission of a response to a given connection will be rate limited. This feature must be used with [proxy-buffering](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#proxy-buffering) enabled.
> - nginx.ingress.kubernetes.io/limit-rate: number of kilobytes per second allowed to send to a given connection. The zero value disables rate limiting. This feature must be used with [proxy-buffering](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#proxy-buffering) enabled.
> - nginx.ingress.kubernetes.io/limit-whitelist: client IP source ranges to be excluded from rate-limiting. The value is a comma separated list of CIDRs.