### PR TITLE
Data Hub: Move other Airflow services to data-hub-services node pool

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -468,19 +468,48 @@ spec:
         secret:
           secretName: surveymonkey-credentials
     postgresql:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 200Mi
           cpu: 100m
       persistence:
         size: 25Gi
+    redis:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
     flower:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 264Mi
           cpu: 50m
           ephemeral-storage: "50Mi"
     scheduler:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 1733Mi
@@ -536,18 +565,39 @@ spec:
         secret:
           secretName: credentials
     triggerer:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           ephemeral-storage: "50Mi"
           memory: 837Mi
           cpu: 200m
     dbMigrations:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 153Mi
           cpu: 50m
           ephemeral-storage: "50Mi"
     pgbouncer:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 100Mi

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -475,18 +475,47 @@ spec:
         secret:
           secretName: surveymonkey-credentials
     postgresql:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 200Mi
           cpu: 100m
           ephemeral-storage: "10Mi"
+    redis:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
     flower:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 230Mi
           cpu: 10m
           ephemeral-storage: "50Mi"
     scheduler:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 1733Mi
@@ -542,14 +571,35 @@ spec:
         secret:
           secretName: credentials
     triggerer:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           ephemeral-storage: "50Mi"
     dbMigrations:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           ephemeral-storage: "50Mi"
     pgbouncer:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           ephemeral-storage: "10Mi"

--- a/deployments/data-hub/release-data-hub--test.yaml
+++ b/deployments/data-hub/release-data-hub--test.yaml
@@ -260,18 +260,47 @@ spec:
         secret:
           secretName: surveymonkey-credentials
     postgresql:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 200Mi
           cpu: 100m
           ephemeral-storage: "10Mi"
+    redis:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
     flower:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 100Mi
           cpu: 50m
           ephemeral-storage: "50Mi"
     scheduler:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           memory: 1733Mi
@@ -328,14 +357,35 @@ spec:
         secret:
           secretName: credentials
     triggerer:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           ephemeral-storage: "50Mi"
     dbMigrations:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           ephemeral-storage: "50Mi"
     pgbouncer:
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: "services"
+          effect: NoSchedule
+      nodeSelector:
+        data-hub-workload: "services"
       resources:
         requests:
           ephemeral-storage: "10Mi"


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1000

Except the `worker`.

We also added config for `redis` (but no resources config for it yet).