### PR TITLE
Data Hub: Fix postgresql and redis tolerations and node selector config

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -468,27 +468,29 @@ spec:
         secret:
           secretName: surveymonkey-credentials
     postgresql:
-      tolerations:
-        - key: workload
-          operator: Equal
-          value: "services"
-          effect: NoSchedule
-      nodeSelector:
-        data-hub-workload: "services"
       resources:
         requests:
           memory: 200Mi
           cpu: 100m
       persistence:
         size: 25Gi
+      master:
+        tolerations:
+          - key: workload
+            operator: Equal
+            value: "services"
+            effect: NoSchedule
+        nodeSelector:
+          data-hub-workload: "services"
     redis:
-      tolerations:
-        - key: workload
-          operator: Equal
-          value: "services"
-          effect: NoSchedule
-      nodeSelector:
-        data-hub-workload: "services"
+      master:
+        tolerations:
+          - key: workload
+            operator: Equal
+            value: "services"
+            effect: NoSchedule
+        nodeSelector:
+          data-hub-workload: "services"
     flower:
       tolerations:
         - key: workload

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -475,26 +475,28 @@ spec:
         secret:
           secretName: surveymonkey-credentials
     postgresql:
-      tolerations:
-        - key: workload
-          operator: Equal
-          value: "services"
-          effect: NoSchedule
-      nodeSelector:
-        data-hub-workload: "services"
       resources:
         requests:
           memory: 200Mi
           cpu: 100m
           ephemeral-storage: "10Mi"
+      master:
+        tolerations:
+          - key: workload
+            operator: Equal
+            value: "services"
+            effect: NoSchedule
+        nodeSelector:
+          data-hub-workload: "services"
     redis:
-      tolerations:
-        - key: workload
-          operator: Equal
-          value: "services"
-          effect: NoSchedule
-      nodeSelector:
-        data-hub-workload: "services"
+      master:
+        tolerations:
+          - key: workload
+            operator: Equal
+            value: "services"
+            effect: NoSchedule
+        nodeSelector:
+          data-hub-workload: "services"
     flower:
       tolerations:
         - key: workload

--- a/deployments/data-hub/release-data-hub--test.yaml
+++ b/deployments/data-hub/release-data-hub--test.yaml
@@ -260,26 +260,28 @@ spec:
         secret:
           secretName: surveymonkey-credentials
     postgresql:
-      tolerations:
-        - key: workload
-          operator: Equal
-          value: "services"
-          effect: NoSchedule
-      nodeSelector:
-        data-hub-workload: "services"
       resources:
         requests:
           memory: 200Mi
           cpu: 100m
           ephemeral-storage: "10Mi"
+      master:
+        tolerations:
+          - key: workload
+            operator: Equal
+            value: "services"
+            effect: NoSchedule
+        nodeSelector:
+          data-hub-workload: "services"
     redis:
-      tolerations:
-        - key: workload
-          operator: Equal
-          value: "services"
-          effect: NoSchedule
-      nodeSelector:
-        data-hub-workload: "services"
+      master:
+        tolerations:
+          - key: workload
+            operator: Equal
+            value: "services"
+            effect: NoSchedule
+        nodeSelector:
+          data-hub-workload: "services"
     flower:
       tolerations:
         - key: workload


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1000

It looks like we need to configure those options within the `master` instead