### PR TITLE
Data Hub: Allow more time for airflow-web to start

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -556,8 +556,14 @@ spec:
           ephemeral-storage: "100Mi"
       livenessProbe:
         initialDelaySeconds: 60
+        periodSeconds: 30
+        timeoutSeconds: 30
+        failureThreshold: 10
       readinessProbe:
         initialDelaySeconds: 60
+        periodSeconds: 30
+        timeoutSeconds: 30
+        failureThreshold: 10
       extraVolumeMounts:
       - name: aws-secret-volume
         mountPath: /home/airflow/.aws

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -562,8 +562,14 @@ spec:
           ephemeral-storage: "100Mi"
       livenessProbe:
         initialDelaySeconds: 60
+        periodSeconds: 30
+        timeoutSeconds: 30
+        failureThreshold: 10
       readinessProbe:
         initialDelaySeconds: 60
+        periodSeconds: 30
+        timeoutSeconds: 30
+        failureThreshold: 10
       extraVolumeMounts:
       - name: aws-secret-volume
         mountPath: /home/airflow/.aws

--- a/deployments/data-hub/release-data-hub--test.yaml
+++ b/deployments/data-hub/release-data-hub--test.yaml
@@ -348,8 +348,14 @@ spec:
           ephemeral-storage: "100Mi"
       livenessProbe:
         initialDelaySeconds: 60
+        periodSeconds: 30
+        timeoutSeconds: 30
+        failureThreshold: 10
       readinessProbe:
         initialDelaySeconds: 60
+        periodSeconds: 30
+        timeoutSeconds: 30
+        failureThreshold: 10
       extraVolumeMounts:
       - name: aws-secret-volume
         mountPath: /home/airflow/.aws


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1000

airflow-web keeps getting killed before it was able to start up.