### PR TITLE
Data Hub: Increase postgresql requests and limits (prod)

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -470,8 +470,11 @@ spec:
     postgresql:
       resources:
         requests:
-          memory: 200Mi
+          memory: 4500Mi
           cpu: 100m
+        limits:
+          memory: 4500Mi
+          cpu: 1000m
       persistence:
         size: 25Gi
       master:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1000

We observed up to 4 GB previously.
We think it may get killed due to sudden high memory usage that isn't recorded.