### PR TITLE
Data Hub: Web API: Enable cursor pagination for OpenAlex

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -694,7 +694,7 @@ webApi:
     dataUrl:
       urlExcludingConfigurableParameters: 'https://api.openalex.org/works?filter=type:preprint'
       configurableParameters:
-        # nextPageCursorParameterName: 'cursor'
+        nextPageCursorParameterName: 'cursor'
         pageSizeParameterName: 'per-page'
         defaultPageSize: 200
     response:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/995

This was accidentally commented out in the previous PR