### PR TITLE
Data Hub: K8s: Reduce duplication in configuration using jinja2 templating

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml.jinja2
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml.jinja2
@@ -1,3 +1,57 @@
+{% macro web_api_pipeline(data_pipeline_id) -%}
+  - dataPipelineId: 'Web_API_{{ data_pipeline_id }}_Kubernetes'
+    airflow:
+      dagParameters:
+        schedule: '25 2 * * *'  # At 02:25 am
+        max_active_runs: 1
+        tags:
+          - 'Kubernetes'
+          - 'Web API'
+    image: 'docker.io/elifesciences/data-hub-core-dags_unstable:latest'
+    imagePullPolicy: Always
+    arguments: 
+      - 'python'
+      - '-m'
+      - 'data_pipeline.generic_web_api.cli'
+      - '--data-pipeline-id={{data_pipeline_id}}'
+    env:
+      - name: DEPLOYMENT_ENV
+        value: '{ENV}'
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /dag_secret_files/gcloud/credentials.json
+      - name: AWS_CONFIG_FILE
+        value: /dag_secret_files/aws/credentials
+      - name: WEB_API_CONFIG_FILE_PATH
+        value: /dag_config_files/web-api-data-pipeline.config.yaml
+    volumeMounts:
+      - name: gcloud-secret-volume
+        mountPath: /dag_secret_files/gcloud/
+        readOnly: true
+      - name: aws-secret-volume
+        mountPath: /dag_secret_files/aws
+        readOnly: true
+      - name: data-hub-config-volume
+        mountPath: /dag_config_files/
+        readOnly: true
+    volumes:
+      - name: aws-secret-volume
+        secret:
+          secretName: credentials
+      - name: gcloud-secret-volume
+        secret:
+          secretName: gcloud
+      - name: data-hub-config-volume
+        configMap:
+          name: data-hub-configs
+    resources:
+      limits:
+        memory: 600Mi
+        cpu: 1000m
+      requests:
+        memory: 500Mi
+        cpu: 100m
+{%- endmacro -%}
+
 kubernetesPipelines:
 
   - dataPipelineId: 'Elife_Article_Xml_Pipeline_Kubernetes'
@@ -322,57 +376,7 @@ kubernetesPipelines:
         memory: 1Gi
         cpu: 100m
 
-  - dataPipelineId: 'Web_API_elife_observer_api_publication_dates_Kubernetes'
-    airflow:
-      dagParameters:
-        schedule: '25 2 * * *'  # At 02:25 am
-        max_active_runs: 1
-        tags:
-          - 'Kubernetes'
-          - 'Web API'
-    image: 'docker.io/elifesciences/data-hub-core-dags_unstable:latest'
-    imagePullPolicy: Always
-    arguments: 
-      - 'python'
-      - '-m'
-      - 'data_pipeline.generic_web_api.cli'
-      - '--data-pipeline-id=elife_observer_api_publication_dates'
-    env:
-      - name: DEPLOYMENT_ENV
-        value: '{ENV}'
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /dag_secret_files/gcloud/credentials.json
-      - name: AWS_CONFIG_FILE
-        value: /dag_secret_files/aws/credentials
-      - name: WEB_API_CONFIG_FILE_PATH
-        value: /dag_config_files/web-api-data-pipeline.config.yaml
-    volumeMounts:
-      - name: gcloud-secret-volume
-        mountPath: /dag_secret_files/gcloud/
-        readOnly: true
-      - name: aws-secret-volume
-        mountPath: /dag_secret_files/aws
-        readOnly: true
-      - name: data-hub-config-volume
-        mountPath: /dag_config_files/
-        readOnly: true
-    volumes:
-      - name: aws-secret-volume
-        secret:
-          secretName: credentials
-      - name: gcloud-secret-volume
-        secret:
-          secretName: gcloud
-      - name: data-hub-config-volume
-        configMap:
-          name: data-hub-configs
-    resources:
-      limits:
-        memory: 600Mi
-        cpu: 1000m
-      requests:
-        memory: 500Mi
-        cpu: 100m
+  {{ web_api_pipeline('elife_observer_api_publication_dates') }}
 
   - dataPipelineId: 'Web_API_elife_people_api_people_staff_profile_Kubernetes'
     airflow:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1003

This is an alternative to using yaml anchors. It requires us to put jinja2 in before loading the yaml files.

As it's templating, it is more flexible and allows us to split files or iterate over things etc.