### PR TITLE
Data Hub: K8s: Mount large-temp-volume to correct path

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
@@ -1514,7 +1514,7 @@ kubernetesPipelines:
         mountPath: /dag_config_files/
         readOnly: true
       - name: large-temp-volume
-        mountPath: /tmp
+        mountPath: /var/tmp
         readOnly: false
     volumes:
       - name: aws-secret-volume


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/995

The correct temp directory seem to be `/var/tmp`:

```console
$ ls -la /var/tmp/tmpx8otzcsa/
total 524544
drwx------ 2 airflow root        41 Oct 18 10:51 .
drwxrwxrwt 1 root    root        25 Oct 18 10:51 ..
-rw-r--r-- 1 airflow root 299769736 Oct 18 10:59 downloaded_jsonl_data.jsonl
```

Otherwise `/tmp` stays empty:

```console
$ ls -la /tmp
total 20
drwxr-xr-x 3 root root  4096 Oct 18 10:51 .
drwxr-xr-x 1 root root   110 Oct 18 10:51 ..
drwx------ 2 root root 16384 Oct 18 10:51 lost+found
```