### PR TITLE
Data Hub: K8s: Attempt to fix large-temp-volume mount for OpenAlex pipeline

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
@@ -1503,6 +1503,8 @@ kubernetesPipelines:
         value: /dag_secret_files/aws/credentials
       - name: WEB_API_CONFIG_FILE_PATH
         value: /dag_config_files/web-api-data-pipeline.config.yaml
+      - name: TMPDIR
+        value: /tmp
     volumeMounts:
       - name: gcloud-secret-volume
         mountPath: /dag_secret_files/gcloud/
@@ -1514,7 +1516,7 @@ kubernetesPipelines:
         mountPath: /dag_config_files/
         readOnly: true
       - name: large-temp-volume
-        mountPath: /var/tmp
+        mountPath: /tmp
         readOnly: false
     volumes:
       - name: aws-secret-volume


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/995

Back to mounting to /tmp

Setting TMPDIR in the hope that it will then use that.