### PR TITLE
Data Hub: Web API: OpenAlex: Added missing state file config

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -689,6 +689,9 @@ webApi:
         schedule: null
     dataset: '{ENV}'
     table: openalex_works_api_response
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/generic-web-api/{ENV}-openalex_works_metadata_for_preprints-state.json'
     urlSourceType:
       # Note: We currently need to use `crossref_metadata_api` for the cursor parameter to work
       # It is also currently required for the `filter` parameter support


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/995

Follow-up to https://github.com/elifesciences/elife-flux-cluster/pull/3080

This adds the missing state file config.
Without the state file, other relevant config wasn't used.