### PR TITLE
Data Hub: K8s: Use explicit tag for OpenAlex pipeline instead of latest

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
@@ -1490,7 +1490,7 @@ kubernetesPipelines:
         security_context:
           runAsUser: 0  # 0 is the root user ID
           runAsGroup: 0  # 0 is the root group ID
-    image: 'docker.io/elifesciences/data-hub-core-dags_unstable:latest'
+    image: 'docker.io/elifesciences/data-hub-core-dags_unstable:HEAD-dbf1ac61-20241022.0912'
     imagePullPolicy: Always
     arguments: 
       - 'python'


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/995

To ensure it is using the latest image for the OpenAlex pipeline as we can't rely on the [image pull policy in combination with spegel](https://github.com/spegel-org/spegel/blob/main/docs/FAQ.md#why-am-i-not-able-to-pull-the-new-version-of-my-tagged-image).

In this case it would still continue to work with the previous image but effectively ignore the publication date filter.