### PR TITLE
Data Hub: Web API: Update bioRxiv meca paths v2 before 29 Dec 2024

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -463,6 +463,7 @@ webApi:
               CONCAT(meca_path_metadata.tdm_doi, 'v', meca_path_metadata.ms_version) AS biorxiv_versioned_doi
             FROM `elife-data-pipeline.{ENV}.biorxiv_medrxiv_meca_path_metadata_v2_api_response`
             JOIN UNNEST(results) AS meca_path_metadata
+            WHERE imported_timestamp >= '2024-11-29'
         keyFieldNameFromInclude: 'biorxiv_versioned_doi'
     urlSourceType:
       name: 'single_source_value'


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1038