### PR TITLE
Data Hub: K8s: Web API: Fixed OpenAlex pipeline after Python 3.9 upgrade

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline--stg.config.yaml
@@ -1561,7 +1561,7 @@ kubernetesPipelines:
       - name: TMPDIR
         value: /tmp
       - name: PYTHONPATH
-        value: /home/airflow/.local/lib/python3.8/site-packages
+        value: /home/airflow/.local/lib/python3.9/site-packages
     volumeMounts:
       - name: gcloud-secret-volume
         mountPath: /dag_secret_files/gcloud/


### PR DESCRIPTION
It was failing with something like:

> [2024-12-06, 17:29:58 UTC] {pod_manager.py:418} INFO - [base]   File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
> [2024-12-06, 17:29:58 UTC] {pod_manager.py:418} INFO - [base]     return _run_code(code, main_globals, None,
> [2024-12-06, 17:29:58 UTC] {pod_manager.py:418} INFO - [base]   File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
> [2024-12-06, 17:29:58 UTC] {pod_manager.py:418} INFO - [base]     exec(code, run_globals)
> [2024-12-06, 17:29:58 UTC] {pod_manager.py:418} INFO - [base]   File "/opt/***/data_pipeline/generic_web_api/cli.py", line 3, in <module>
> [2024-12-06, 17:29:58 UTC] {pod_manager.py:418} INFO - [base]     from data_pipeline.generic_web_api.generic_web_api_config import (
> [2024-12-06, 17:29:58 UTC] {pod_manager.py:418} INFO - [base]   File "/opt/***/data_pipeline/generic_web_api/generic_web_api_config.py", line 5, in <module>
> [2024-12-06, 17:29:58 UTC] {pod_manager.py:418} INFO - [base]     from google.cloud.bigquery import WriteDisposition
> [2024-12-06, 17:29:58 UTC] {pod_manager.py:418} INFO - [base] ModuleNotFoundError: No module named 'google'