### PR TITLE
Data Hub: Web API: Fixed SpaCy request builder

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -814,7 +814,7 @@ webApi:
             JOIN UNNEST(response.data) AS extract_keyword_result
         keyFieldNameFromInclude: 'change_id'
     requestBuilder:
-      name: 'spacy_keyword_extraction'
+      name: 'spacy_batch_keyword_extraction_api'
     dataUrl:
       urlExcludingConfigurableParameters: https://spacy-keyword-extraction-api.elifesciences.org/v1/batch-extract-keywords
     response:
@@ -851,7 +851,7 @@ webApi:
             JOIN UNNEST(response.data) AS extract_keyword_result
         keyFieldNameFromInclude: 'change_id'
     requestBuilder:
-      name: 'spacy_keyword_extraction'
+      name: 'spacy_batch_keyword_extraction_api'
     dataUrl:
       urlExcludingConfigurableParameters: https://spacy-keyword-extraction-api.elifesciences.org/v1/batch-extract-keywords
     response:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1046

related to https://github.com/elifesciences/data-hub-issues/issues/1048

This should use the new `spacy_batch_keyword_extraction_api`.