### PR TITLE
PeerScout: SpaCy API: Increased CPU limit

### DIFF
--- a/deployments/peerscout/spacy-keyword-extraction-api/spacy-keyword-extraction-api--prod.yaml
+++ b/deployments/peerscout/spacy-keyword-extraction-api/spacy-keyword-extraction-api--prod.yaml
@@ -6,6 +6,7 @@ metadata:
     app: spacy-keyword-extraction-api--prod
   namespace: peerscout
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: spacy-keyword-extraction-api--prod

--- a/deployments/peerscout/spacy-keyword-extraction-api/spacy-keyword-extraction-api--prod.yaml
+++ b/deployments/peerscout/spacy-keyword-extraction-api/spacy-keyword-extraction-api--prod.yaml
@@ -41,7 +41,7 @@ spec:
             cpu: 100m
             memory: 2.6Gi
           limits:
-            cpu: 500m
+            cpu: 1500m
             memory: 3Gi
 ---
 apiVersion: v1


### PR DESCRIPTION
Related to https://github.com/elifesciences/data-hub-issues/issues/1046

This is to allow it to process keywords faster. At least temporarily.