### PR TITLE
Data Hub: Web API: Adjust batch size and max source values per request

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -815,11 +815,12 @@ webApi:
         keyFieldNameFromInclude: 'change_id'
     requestBuilder:
       name: 'spacy_batch_keyword_extraction_api'
+      maxSourceValuesPerRequest: 20
     dataUrl:
       urlExcludingConfigurableParameters: https://spacy-keyword-extraction-api.elifesciences.org/v1/batch-extract-keywords
     response:
       provenanceEnabled: True
-    batchSize: 100
+    batchSize: 25
 
   - dataPipelineId: keywords_from_disambiguated_editor_papers_abstract_batch
     dataset: '{ENV}'
@@ -852,8 +853,9 @@ webApi:
         keyFieldNameFromInclude: 'change_id'
     requestBuilder:
       name: 'spacy_batch_keyword_extraction_api'
+      maxSourceValuesPerRequest: 20
     dataUrl:
       urlExcludingConfigurableParameters: https://spacy-keyword-extraction-api.elifesciences.org/v1/batch-extract-keywords
     response:
       provenanceEnabled: True
-    batchSize: 100
+    batchSize: 25


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1046

related to https://github.com/elifesciences/data-hub-issues/issues/1048

related to https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1583

Increase max source values per request to reduce API overhead.
Reduce batch size to write to BigQuery more frequently.

i.e.

from: every 100 batches or 100 * 10 = 1000 records

to: every 25 batches, or 25 * 20 = 500 records