### PR TITLE
PeerScout: SpaCy API: Increase timeout to 5m

### DIFF
--- a/deployments/peerscout/spacy-keyword-extraction-api/spacy-keyword-extraction-api--prod.yaml
+++ b/deployments/peerscout/spacy-keyword-extraction-api/spacy-keyword-extraction-api--prod.yaml
@@ -63,6 +63,10 @@ metadata:
   namespace: peerscout
   labels:
     app: spacy-keyword-extraction-api--prod
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
 spec:
   rules:
     - host: spacy-keyword-extraction-api.elifesciences.org


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/1047

Sometimes the configured max source values can and concurrent requests can cause it to process requests slower than 60 seconds. This gives it up to 5m to process requests.