### PR TITLE
PeerScout: Spacy API: Increase replicas further to 3 (prod)

### DIFF
--- a/deployments/peerscout/spacy-keyword-extraction-api/spacy-keyword-extraction-api--prod.yaml
+++ b/deployments/peerscout/spacy-keyword-extraction-api/spacy-keyword-extraction-api--prod.yaml
@@ -6,7 +6,7 @@ metadata:
     app: spacy-keyword-extraction-api--prod
   namespace: peerscout
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: spacy-keyword-extraction-api--prod


### PR DESCRIPTION
Related to https://github.com/elifesciences/data-hub-issues/issues/1046

Up from 2
(While pipelines are catching up, we have 4 running - 2 for staging, 2 for prod)