### PR TITLE
Data Hub: Web API: Timeout for SpaCy keyword extraction pipelines (120 seconds)

### DIFF
--- a/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
+++ b/kustomizations/apps/data-hub-configs/web-api-data-pipeline.config.yaml
@@ -813,6 +813,7 @@ webApi:
             FROM `elife-data-pipeline.{ENV}.keywords_from_manuscript_abstract_batch` AS response
             JOIN UNNEST(response.data) AS extract_keyword_result
         keyFieldNameFromInclude: 'change_id'
+    timeout: 120
     requestBuilder:
       name: 'spacy_batch_keyword_extraction_api'
       maxSourceValuesPerRequest: 20
@@ -851,6 +852,7 @@ webApi:
             FROM `elife-data-pipeline.{ENV}.keywords_from_disambiguated_editor_papers_abstract_batch` AS response
             JOIN UNNEST(response.data) AS extract_keyword_result
         keyFieldNameFromInclude: 'change_id'
+    timeout: 120
     requestBuilder:
       name: 'spacy_batch_keyword_extraction_api'
       maxSourceValuesPerRequest: 20


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/1052

depends on https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1584