### PR TITLE
[Data Hub]: Remove placeholder for DEPLOYMENT_ENV

### DIFF
--- a/kustomizations/apps/data-hub-configs/kubernetes-pipeline-other-pipelines--stg.config.yaml
+++ b/kustomizations/apps/data-hub-configs/kubernetes-pipeline-other-pipelines--stg.config.yaml
@@ -7,7 +7,7 @@ defaultConfig:
         - 'Kubernetes'
   env:
     - name: DEPLOYMENT_ENV
-      value: '{ENV}'
+      value: staging
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /dag_secret_files/gcloud/credentials.json
     - name: AWS_CONFIG_FILE


### PR DESCRIPTION
Fix for `[2025-01-24, 17:42:16 UTC] {pod_manager.py:418} INFO - [base] Invalid bucket name "{ENV}-elife-data-pipeline": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:(s3|s3-object-lambda):[a-z\-0-9]*:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-.]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$"
`