### PR TITLE
[Data Hub]: Update Google SpreadSheet pipeline schedular interval

### DIFF
--- a/deployments/data-hub/release-data-hub--prod.yaml
+++ b/deployments/data-hub/release-data-hub--prod.yaml
@@ -124,9 +124,9 @@ spec:
         value: "0 7 * * 1-5"
       - name: CROSS_REF_IMPORT_SCHEDULE_INTERVAL
         value: "@daily"
-        # At minute 20 past every hour from 5 through 19 on every day-of-week from Monday through Friday.
+        # At minute 0, 20, and 40 past every hour from 3 through 22 on every day-of-week from Monday through Friday.
       - name: GOOGLE_SPREADSHEET_SCHEDULE_INTERVAL
-        value: "20 4-19/1 * * 1-5"
+        value: "0,20,40 3-22 * * 1-5"
       - name: SEMANTIC_SCHOLAR_PIPELINE_SCHEDULE_INTERVAL
         value: "0 10 * * *" # At 10:00, every day
       - name: SEMANTIC_SCHOLAR_RECOMMENDATION_PIPELINE_SCHEDULE_INTERVAL

--- a/deployments/data-hub/release-data-hub--stg.yaml
+++ b/deployments/data-hub/release-data-hub--stg.yaml
@@ -137,9 +137,9 @@ spec:
         value: "0 7 * * 1-5"
       - name: CROSS_REF_IMPORT_SCHEDULE_INTERVAL
         value: "@daily"
-        # At minute 20 past every hour from 5 through 19 on every day-of-week from Monday through Friday.
+        # At minute 0, 20, and 40 past every hour from 3 through 22 on every day-of-week from Monday through Friday.
       - name: GOOGLE_SPREADSHEET_SCHEDULE_INTERVAL
-        value: "20 4-19/1 * * 1-5"
+        value: "0,20,40 3-22 * * 1-5"
       - name: SEMANTIC_SCHOLAR_PIPELINE_SCHEDULE_INTERVAL
         value: "0 10 * * *" # At 10:00, every day
       - name: SEMANTIC_SCHOLAR_RECOMMENDATION_PIPELINE_SCHEDULE_INTERVAL


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/1073

We meant to run this pipeline every 20 mins but it seems like it is running only at past 20. So we need to first update this.