### PR TITLE
Switch to regular oauth proxy for the Weave GitOps dashboard

### DIFF
--- a/system/gitops-dashboard/release.yaml
+++ b/system/gitops-dashboard/release.yaml
@@ -27,8 +27,8 @@ spec:
         hosts:
         - gitops-dashboard--${cluster_domain}
       annotations:
-        nginx.ingress.kubernetes.io/auth-url: "https://auth--test-cluster.elifesciences.org/oauth2/auth"
-        nginx.ingress.kubernetes.io/auth-signin: "https://auth--test-cluster.elifesciences.org/oauth2/start?rd=https%3A%2F%2F$host$request_uri"
+        nginx.ingress.kubernetes.io/auth-url: "https://oauth-proxy.elifesciences.org/oauth2/auth"
+        nginx.ingress.kubernetes.io/auth-signin: "https://oauth-proxy.elifesciences.org/oauth2/start?rd=https%3A%2F%2F$host$request_uri"
         cert-manager.io/cluster-issuer: letsencrypt
     adminUser:
       create: true


### PR DESCRIPTION
Not sure if this makes sense at all. But since I am encountering random errors, could that be the cause?