### PR TITLE
Fix kubeconform throwing 429 from githubusercontent.com

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,6 +5,6 @@ kubie       0.23.0
 kind        0.28.0
 kustomize   5.6.0
 yq          4.45.4
-kubeconform 0.6.4
+kubeconform 0.7.0
 awscli      2.27.17
 helm        3.17.3


### PR DESCRIPTION
- **upgrade kubeconform**
- **exclude patches from kubeconform, and put debugging behind ENV var for github actions debug, and add more output on failure**
- **Clone repo for offline schemas instead of relying on githubusercontent requests**
