### PR TITLE
Implement KEDA autoscaler for Temporal workers

### DIFF
--- a/deployments/epp/staging/deployment-scaledobject.yaml
+++ b/deployments/epp/staging/deployment-scaledobject.yaml
@@ -1,10 +1,10 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: temporal-worker
+  name: epp-import-worker-epp
 spec:
   scaleTargetRef:
-    name: temporal-worker
+    name: epp-import-worker-epp
     namespace: epp--staging
   minReplicaCount: 1
   maxReplicaCount: 10

--- a/deployments/epp/staging/deployment-scaledobject.yaml
+++ b/deployments/epp/staging/deployment-scaledobject.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: temporal-worker
+    namespace: epp--staging
   minReplicaCount: 1
   maxReplicaCount: 10
   advanced:
@@ -25,7 +26,7 @@ spec:
   triggers:
     - type: temporal
       metadata:
-        namespace: default
+        namespace: epp--staging
         taskQueue: epp
         targetQueueSize: "1"
         endpoint: 7233

--- a/deployments/epp/staging/deployment-scaledobject.yaml
+++ b/deployments/epp/staging/deployment-scaledobject.yaml
@@ -28,5 +28,5 @@ spec:
       metadata:
         namespace: epp--staging
         taskQueue: epp
-        targetQueueSize: "1"
+        targetQueueSize: "10"
         endpoint: 7233

--- a/deployments/epp/staging/deployment-scaledobject.yaml
+++ b/deployments/epp/staging/deployment-scaledobject.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   scaleTargetRef:
     name: epp-import-worker-epp
-    namespace: epp--staging
   minReplicaCount: 1
   maxReplicaCount: 10
   advanced:

--- a/deployments/epp/staging/deployment-scaledobject.yaml
+++ b/deployments/epp/staging/deployment-scaledobject.yaml
@@ -2,6 +2,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: epp-import-worker-epp
+  namespace: epp--staging
 spec:
   scaleTargetRef:
     name: epp-import-worker-epp

--- a/kustomizations/services/temporal/worker/deployment-scaledobject.yaml
+++ b/kustomizations/services/temporal/worker/deployment-scaledobject.yaml
@@ -1,0 +1,35 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: temporal-worker
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/resource-policy": keep
+spec:
+  scaleTargetRef:
+    name: temporal-worker
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 30
+          policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 60
+        scaleDown:
+          stabilizationWindowSeconds: 60
+          policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 60
+  triggers:
+    - type: temporal
+      metadata:
+        namespace: default
+        taskQueue: epp
+        targetQueueSize: "1"
+        endpoint: 7233

--- a/kustomizations/services/temporal/worker/deployment-scaledobject.yaml
+++ b/kustomizations/services/temporal/worker/deployment-scaledobject.yaml
@@ -2,10 +2,6 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: temporal-worker
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/resource-policy": keep
 spec:
   scaleTargetRef:
     name: temporal-worker


### PR DESCRIPTION
This should ensure that workers on Temporal are scaled automatically based on the workload thus saving resources and costs.