### PR TITLE
Revert "Data Hub services node pool: Allow fallback to "on-demand""

### DIFF
--- a/teams/data-hub/nodepool-services.yaml
+++ b/teams/data-hub/nodepool-services.yaml
@@ -30,7 +30,7 @@ spec:
           values: ["linux"]
         - key: karpenter.sh/capacity-type
           operator: In
-          values: ["spot", "on-demand"]
+          values: ["spot"]
         - key: karpenter.k8s.aws/instance-category
           operator: In
           values: ["m", "c", "r", "t"]


### PR DESCRIPTION
Reverts elifesciences/elife-flux-cluster#3942

part of https://github.com/elifesciences/data-hub-issues/issues/1236