### PR TITLE
fix(tests): Patch traefik to deploy in ci correctly

### DIFF
--- a/clusters/end-to-end-tests/system.yaml
+++ b/clusters/end-to-end-tests/system.yaml
@@ -31,6 +31,28 @@ spec:
       aws_cert_manager_service_account_role_arn: "nothing-real"
 
   patches:
+  - target:
+      kind: HelmRelease
+      name: traefik
+    patch: |-
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: traefik
+        namespace: traefik
+      spec:
+        install:
+          disableWait: true # Needed because the test pod doesn't have values to manipulate where it runs
+        values:
+          deployment:
+            replicas: 1
+          tolerations:
+          - key: "realnode"
+            operator: "Equal"
+            value: "true"
+            effect: "NoSchedule"
+          nodeSelector:
+            kubernetes.io/hostname: elife-flux-test-control-plane
   # in a small cluster like kind or minikube the load balancer won't get an external IP.
   # Therefore, we need to disable waiting
   - patch: |-


### PR DESCRIPTION
- only 1 replica
- be scheduled to a "real" node
- don't wait for loadbalancer or tests to pass